### PR TITLE
Support type-cast operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let package = Package(
             targets: ["MyPackage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mipalgu/VHDLParsing", from: "0.1.0")
+        .package(url: "https://github.com/mipalgu/VHDLParsing", from: "0.2.0")
     ],
     targets: [
         .target(

--- a/Sources/VHDLParsing/CastOperation.swift
+++ b/Sources/VHDLParsing/CastOperation.swift
@@ -118,7 +118,6 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
         guard
             trimmedString.count < 256,
             !trimmedString.isEmpty,
-            !trimmedString.hasPrefix("("),
             let firstWord = trimmedString.firstWord?.lowercased()
         else {
             return nil
@@ -199,9 +198,10 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
 private extension Expression {
 
     init?(raw: String, length: Int) {
+        let expressionString = raw.dropFirst(length).trimmingCharacters(in: .whitespacesAndNewlines)
         guard
-            let rawString = raw.dropFirst(length).trimmingCharacters(in: .whitespacesAndNewlines)
-                .uptoBalancedBracket,
+            let rawString = expressionString.uptoBalancedBracket,
+            rawString.endIndex == expressionString.endIndex,
             rawString.hasPrefix("("),
             rawString.hasSuffix(")")
         else {

--- a/Sources/VHDLParsing/CastOperation.swift
+++ b/Sources/VHDLParsing/CastOperation.swift
@@ -1,0 +1,213 @@
+// CastOperation.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Sendable {
+
+    case bit(expression: Expression)
+
+    case bitVector(expression: Expression)
+
+    case boolean(expression: Expression)
+
+    case integer(expression: Expression)
+
+    case natural(expression: Expression)
+
+    case positive(expression: Expression)
+
+    case real(expression: Expression)
+
+    case signed(expression: Expression)
+
+    case stdLogic(expression: Expression)
+
+    case stdLogicVector(expression: Expression)
+
+    case stdULogic(expression: Expression)
+
+    case stdULogicVector(expression: Expression)
+
+    case unsigned(expression: Expression)
+
+    public var rawValue: String {
+        switch self {
+        case .bit(let expression):
+            return "bit(\(expression.rawValue))"
+        case .bitVector(let expression):
+            return "bit_vector(\(expression.rawValue))"
+        case .boolean(let expression):
+            return "boolean(\(expression.rawValue))"
+        case .integer(let expression):
+            return "integer(\(expression.rawValue))"
+        case .natural(let expression):
+            return "natural(\(expression.rawValue))"
+        case .positive(let expression):
+            return "positive(\(expression.rawValue))"
+        case .real(let expression):
+            return "real(\(expression.rawValue))"
+        case .signed(let expression):
+            return "signed(\(expression.rawValue))"
+        case .stdLogic(let expression):
+            return "std_logic(\(expression.rawValue))"
+        case .stdLogicVector(let expression):
+            return "std_logic_vector(\(expression.rawValue))"
+        case .stdULogic(let expression):
+            return "std_ulogic(\(expression.rawValue))"
+        case .stdULogicVector(let expression):
+            return "std_ulogic_vector(\(expression.rawValue))"
+        case .unsigned(let expression):
+            return "unsigned(\(expression.rawValue))"
+        }
+    }
+
+    public init?(rawValue: String) {
+        let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            trimmedString.count < 256,
+            !trimmedString.isEmpty,
+            !trimmedString.hasPrefix("("),
+            let firstWord = trimmedString.firstWord?.lowercased()
+        else {
+            return nil
+        }
+        switch firstWord {
+        case "bit":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .bit(expression: expression)
+        case "bit_vector":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .bitVector(expression: expression)
+        case "boolean":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .boolean(expression: expression)
+        case "integer":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .integer(expression: expression)
+        case "natural":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .natural(expression: expression)
+        case "positive":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .positive(expression: expression)
+        case "real":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .real(expression: expression)
+        case "signed":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .signed(expression: expression)
+        case "std_logic":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .stdLogic(expression: expression)
+        case "std_logic_vector":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .stdLogicVector(expression: expression)
+        case "std_ulogic":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .stdULogic(expression: expression)
+        case "std_ulogic_vector":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .stdULogicVector(expression: expression)
+        case "unsigned":
+            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
+                return nil
+            }
+            self = .unsigned(expression: expression)
+        default:
+            return nil
+        }
+    }
+
+}
+
+private extension Expression {
+
+    init?(raw: String, length: Int) {
+        guard
+            let rawString = raw.dropFirst(length).trimmingCharacters(in: .whitespacesAndNewlines)
+                .uptoBalancedBracket,
+            rawString.hasPrefix("("),
+            rawString.hasSuffix(")")
+        else {
+            return nil
+        }
+        self.init(rawValue: String(rawString.dropFirst().dropLast()))
+    }
+
+}

--- a/Sources/VHDLParsing/CastOperation.swift
+++ b/Sources/VHDLParsing/CastOperation.swift
@@ -131,6 +131,7 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
     /// Creates a new ``CastOperation`` from a `String` representing the `VHDL` code performing the cast
     /// operation.
     /// - Parameter rawValue: The `VHDL` code performing the cast operation.
+    @inlinable
     public init?(rawValue: String) {
         let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
@@ -154,14 +155,20 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
         else {
             return nil
         }
-        self.init(firstWord: firstWord, expression: expression)
+        self.init(type: firstWord, expression: expression)
     }
 
-    init?(firstWord: String, expression: Expression) {
-        guard let maxSize = Set<String>.vhdlSignalTypes.map(\.count).max(), firstWord.count <= maxSize else {
+    /// Creates a new ``CastOperation`` from the type casting to (as a string) and the expression that is to
+    /// be casted.
+    /// - Parameters:
+    ///   - type: The type of the cast operation. This type must not contain any whitespace or newlines.
+    ///   - expression: The expression to cast to the new type.
+    @usableFromInline
+    init?(type: String, expression: Expression) {
+        guard let maxSize = Set<String>.vhdlSignalTypes.map(\.count).max(), type.count <= maxSize else {
             return nil
         }
-        switch firstWord.lowercased() {
+        switch type.lowercased() {
         case "bit":
             self = .bit(expression: expression)
         case "bit_vector":

--- a/Sources/VHDLParsing/CastOperation.swift
+++ b/Sources/VHDLParsing/CastOperation.swift
@@ -128,9 +128,6 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
         }
     }
 
-    // swiftlint:disable function_body_length
-    // swiftlint:disable cyclomatic_complexity
-
     /// Creates a new ``CastOperation`` from a `String` representing the `VHDL` code performing the cast
     /// operation.
     /// - Parameter rawValue: The `VHDL` code performing the cast operation.
@@ -143,79 +140,43 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
         else {
             return nil
         }
+        guard
+            Set<String>.vhdlSignalTypes.contains(firstWord),
+            let expression = Expression(raw: trimmedString, length: firstWord.count)
+        else {
+            return nil
+        }
         switch firstWord {
         case "bit":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .bit(expression: expression)
         case "bit_vector":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .bitVector(expression: expression)
         case "boolean":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .boolean(expression: expression)
         case "integer":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .integer(expression: expression)
         case "natural":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .natural(expression: expression)
         case "positive":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .positive(expression: expression)
         case "real":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .real(expression: expression)
         case "signed":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .signed(expression: expression)
         case "std_logic":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .stdLogic(expression: expression)
         case "std_logic_vector":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .stdLogicVector(expression: expression)
         case "std_ulogic":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .stdULogic(expression: expression)
         case "std_ulogic_vector":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .stdULogicVector(expression: expression)
         case "unsigned":
-            guard let expression = Expression(raw: trimmedString, length: firstWord.count) else {
-                return nil
-            }
             self = .unsigned(expression: expression)
         default:
             return nil
         }
     }
-
-    // swiftlint:enable cyclomatic_complexity
-    // swiftlint:enable function_body_length
 
 }
 

--- a/Sources/VHDLParsing/CastOperation.swift
+++ b/Sources/VHDLParsing/CastOperation.swift
@@ -54,35 +54,50 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+/// A cast operation converting an expression to a specific ``SignalType``.
 public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 
+    /// Convert to a `bit`.
     case bit(expression: Expression)
 
+    /// Convert to a `bit_vector`.
     case bitVector(expression: Expression)
 
+    /// Convert to a `boolean`.
     case boolean(expression: Expression)
 
+    /// Convert to an `integer`.
     case integer(expression: Expression)
 
+    /// Convert to a `natural`.
     case natural(expression: Expression)
 
+    /// Convert to a `positive`.
     case positive(expression: Expression)
 
+    /// Convert to a `real`.
     case real(expression: Expression)
 
+    /// Convert to a `signed`.
     case signed(expression: Expression)
 
+    /// Convert to a `std_logic`.
     case stdLogic(expression: Expression)
 
+    /// Convert to a `std_logic_vector`.
     case stdLogicVector(expression: Expression)
 
+    /// Convert to a `std_ulogic`.
     case stdULogic(expression: Expression)
 
+    /// Convert to a `std_ulogic_vector`.
     case stdULogicVector(expression: Expression)
 
+    /// Convert to an `unsigned`.
     case unsigned(expression: Expression)
 
-    public var rawValue: String {
+    /// The `VHDL` code performing the cast operation.
+    @inlinable public var rawValue: String {
         switch self {
         case .bit(let expression):
             return "bit(\(expression.rawValue))"
@@ -113,6 +128,12 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
         }
     }
 
+    // swiftlint:disable function_body_length
+    // swiftlint:disable cyclomatic_complexity
+
+    /// Creates a new ``CastOperation`` from a `String` representing the `VHDL` code performing the cast
+    /// operation.
+    /// - Parameter rawValue: The `VHDL` code performing the cast operation.
     public init?(rawValue: String) {
         let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
@@ -193,10 +214,18 @@ public enum CastOperation: RawRepresentable, Equatable, Hashable, Codable, Senda
         }
     }
 
+    // swiftlint:enable cyclomatic_complexity
+    // swiftlint:enable function_body_length
+
 }
 
+/// Add extra init for deriving the expression from a cast operation.
 private extension Expression {
 
+    /// Create an expression that exists within a cast operation.
+    /// - Parameters:
+    ///   - raw: The cast operation.
+    ///   - length: The length of the type that the expression is being casted to.
     init?(raw: String, length: Int) {
         let expressionString = raw.dropFirst(length).trimmingCharacters(in: .whitespacesAndNewlines)
         guard

--- a/Sources/VHDLParsing/Expression.swift
+++ b/Sources/VHDLParsing/Expression.swift
@@ -84,6 +84,9 @@ indirect public enum Expression: RawRepresentable,
     /// A boolean logic expression.
     case logical(operation: BooleanExpression)
 
+    /// A type-cast operation.
+    case cast(operation: CastOperation)
+
     /// The raw value is a string.
     public typealias RawValue = String
 
@@ -101,6 +104,8 @@ indirect public enum Expression: RawRepresentable,
         case .conditional(let condition):
             return condition.rawValue
         case .logical(let operation):
+            return operation.rawValue
+        case .cast(let operation):
             return operation.rawValue
         }
     }
@@ -122,6 +127,10 @@ indirect public enum Expression: RawRepresentable,
         }
         if let literal = SignalLiteral(rawValue: value) {
             self = .literal(value: literal)
+            return
+        }
+        if let cast = CastOperation(rawValue: value) {
+            self = .cast(operation: cast)
             return
         }
         if

--- a/Sources/VHDLParsing/Expression.swift
+++ b/Sources/VHDLParsing/Expression.swift
@@ -120,6 +120,7 @@ indirect public enum Expression: RawRepresentable,
 
     /// Create an `Expression` from valid VHDL code.
     /// - Parameter rawValue: The code to convert to this expression.
+    @inlinable
     public init?(rawValue: String) {
         let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard value.count < 256 else {

--- a/Tests/VHDLParsingTests/CastOperationTests.swift
+++ b/Tests/VHDLParsingTests/CastOperationTests.swift
@@ -136,4 +136,29 @@ final class CastOperationTests: XCTestCase {
         XCTAssertNil(CastOperation(rawValue: "unsigned(x))"))
     }
 
+    /// Test that `init(firstWord:, expression:)` created the correct case.
+    func testWordInit() {
+        XCTAssertEqual(CastOperation(firstWord: "bit", expression: x), .bit(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "bit_vector", expression: x), .bitVector(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "boolean", expression: x), .boolean(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "integer", expression: x), .integer(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "natural", expression: x), .natural(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "positive", expression: x), .positive(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "real", expression: x), .real(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "signed", expression: x), .signed(expression: x))
+        XCTAssertEqual(CastOperation(firstWord: "std_logic", expression: x), .stdLogic(expression: x))
+        XCTAssertEqual(
+            CastOperation(firstWord: "std_logic_vector", expression: x),
+            .stdLogicVector(expression: x)
+        )
+        XCTAssertEqual(CastOperation(firstWord: "std_ulogic", expression: x), .stdULogic(expression: x))
+        XCTAssertEqual(
+            CastOperation(firstWord: "std_ulogic_vector", expression: x),
+            .stdULogicVector(expression: x)
+        )
+        XCTAssertEqual(CastOperation(firstWord: "unsigned", expression: x), .unsigned(expression: x))
+        XCTAssertNil(CastOperation(firstWord: "bits", expression: x))
+        XCTAssertNil(CastOperation(firstWord: "std_ulogic_vectors", expression: x))
+    }
+
 }

--- a/Tests/VHDLParsingTests/CastOperationTests.swift
+++ b/Tests/VHDLParsingTests/CastOperationTests.swift
@@ -1,0 +1,139 @@
+// CastOperationTests.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLParsing
+import XCTest
+
+/// Test class for ``CastOperation``.
+final class CastOperationTests: XCTestCase {
+
+    /// A variable `x`.
+    let x = Expression.variable(name: VariableName(text: "x"))
+
+    /// Test the raw values generate the correct `VHDL` code.
+    func testRawValue() {
+        XCTAssertEqual(CastOperation.bit(expression: x).rawValue, "bit(x)")
+        XCTAssertEqual(CastOperation.bitVector(expression: x).rawValue, "bit_vector(x)")
+        XCTAssertEqual(CastOperation.boolean(expression: x).rawValue, "boolean(x)")
+        XCTAssertEqual(CastOperation.integer(expression: x).rawValue, "integer(x)")
+        XCTAssertEqual(CastOperation.natural(expression: x).rawValue, "natural(x)")
+        XCTAssertEqual(CastOperation.positive(expression: x).rawValue, "positive(x)")
+        XCTAssertEqual(CastOperation.real(expression: x).rawValue, "real(x)")
+        XCTAssertEqual(CastOperation.signed(expression: x).rawValue, "signed(x)")
+        XCTAssertEqual(CastOperation.stdLogic(expression: x).rawValue, "std_logic(x)")
+        XCTAssertEqual(CastOperation.stdLogicVector(expression: x).rawValue, "std_logic_vector(x)")
+        XCTAssertEqual(CastOperation.stdULogic(expression: x).rawValue, "std_ulogic(x)")
+        XCTAssertEqual(CastOperation.stdULogicVector(expression: x).rawValue, "std_ulogic_vector(x)")
+        XCTAssertEqual(CastOperation.unsigned(expression: x).rawValue, "unsigned(x)")
+    }
+
+    /// Test the `init(rawValue:)` for bit types.
+    func testBitRawInit() {
+        XCTAssertEqual(CastOperation(rawValue: "bit(x)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "BIT(x)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit (x)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit( x)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit ( x)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit(x )"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit (x )"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit( x )"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit ( x )"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: " bit(x)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit(x) "), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: " bit(x) "), CastOperation.bit(expression: x))
+        XCTAssertEqual(CastOperation(rawValue: "bit(\n    x\n)"), CastOperation.bit(expression: x))
+        XCTAssertEqual(
+            CastOperation(rawValue: "bit((x))"), CastOperation.bit(expression: .precedence(value: x))
+        )
+        XCTAssertNil(CastOperation(rawValue: "bit((x)"))
+        XCTAssertNil(CastOperation(rawValue: "bit((x)))"))
+        XCTAssertNil(CastOperation(rawValue: "bit(\(String(repeating: "x", count: 256)))"))
+        XCTAssertNil(CastOperation(rawValue: "bit(x) + y"))
+        XCTAssertNil(CastOperation(rawValue: "bits(x)"))
+        XCTAssertNil(CastOperation(rawValue: ""))
+        XCTAssertNil(CastOperation(rawValue: "(bit(x))"))
+        XCTAssertNil(CastOperation(rawValue: ";bit(x)"))
+    }
+
+    /// Test the `init(rawValue:)` for the remaining types.
+    func testRemainingRawInit() {
+        XCTAssertEqual(CastOperation(rawValue: "bit_vector(x)"), .bitVector(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "bit_vector(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "boolean(x)"), .boolean(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "boolean(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "integer(x)"), .integer(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "integer(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "natural(x)"), .natural(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "natural(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "positive(x)"), .positive(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "positive(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "real(x)"), .real(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "real(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "signed(x)"), .signed(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "signed(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "std_logic(x)"), .stdLogic(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "std_logic(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "std_logic_vector(x)"), .stdLogicVector(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "std_logic_vector(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "std_ulogic(x)"), .stdULogic(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "std_ulogic(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "std_ulogic_vector(x)"), .stdULogicVector(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "std_ulogic_vector(x))"))
+        XCTAssertEqual(CastOperation(rawValue: "unsigned(x)"), .unsigned(expression: x))
+        XCTAssertNil(CastOperation(rawValue: "unsigned(x))"))
+    }
+
+}

--- a/Tests/VHDLParsingTests/CastOperationTests.swift
+++ b/Tests/VHDLParsingTests/CastOperationTests.swift
@@ -138,27 +138,27 @@ final class CastOperationTests: XCTestCase {
 
     /// Test that `init(firstWord:, expression:)` created the correct case.
     func testWordInit() {
-        XCTAssertEqual(CastOperation(firstWord: "bit", expression: x), .bit(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "bit_vector", expression: x), .bitVector(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "boolean", expression: x), .boolean(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "integer", expression: x), .integer(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "natural", expression: x), .natural(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "positive", expression: x), .positive(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "real", expression: x), .real(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "signed", expression: x), .signed(expression: x))
-        XCTAssertEqual(CastOperation(firstWord: "std_logic", expression: x), .stdLogic(expression: x))
+        XCTAssertEqual(CastOperation(type: "bit", expression: x), .bit(expression: x))
+        XCTAssertEqual(CastOperation(type: "bit_vector", expression: x), .bitVector(expression: x))
+        XCTAssertEqual(CastOperation(type: "boolean", expression: x), .boolean(expression: x))
+        XCTAssertEqual(CastOperation(type: "integer", expression: x), .integer(expression: x))
+        XCTAssertEqual(CastOperation(type: "natural", expression: x), .natural(expression: x))
+        XCTAssertEqual(CastOperation(type: "positive", expression: x), .positive(expression: x))
+        XCTAssertEqual(CastOperation(type: "real", expression: x), .real(expression: x))
+        XCTAssertEqual(CastOperation(type: "signed", expression: x), .signed(expression: x))
+        XCTAssertEqual(CastOperation(type: "std_logic", expression: x), .stdLogic(expression: x))
         XCTAssertEqual(
-            CastOperation(firstWord: "std_logic_vector", expression: x),
+            CastOperation(type: "std_logic_vector", expression: x),
             .stdLogicVector(expression: x)
         )
-        XCTAssertEqual(CastOperation(firstWord: "std_ulogic", expression: x), .stdULogic(expression: x))
+        XCTAssertEqual(CastOperation(type: "std_ulogic", expression: x), .stdULogic(expression: x))
         XCTAssertEqual(
-            CastOperation(firstWord: "std_ulogic_vector", expression: x),
+            CastOperation(type: "std_ulogic_vector", expression: x),
             .stdULogicVector(expression: x)
         )
-        XCTAssertEqual(CastOperation(firstWord: "unsigned", expression: x), .unsigned(expression: x))
-        XCTAssertNil(CastOperation(firstWord: "bits", expression: x))
-        XCTAssertNil(CastOperation(firstWord: "std_ulogic_vectors", expression: x))
+        XCTAssertEqual(CastOperation(type: "unsigned", expression: x), .unsigned(expression: x))
+        XCTAssertNil(CastOperation(type: "bits", expression: x))
+        XCTAssertNil(CastOperation(type: "std_ulogic_vectors", expression: x))
     }
 
 }

--- a/Tests/VHDLParsingTests/ExpressionTests.swift
+++ b/Tests/VHDLParsingTests/ExpressionTests.swift
@@ -115,6 +115,9 @@ final class ExpressionTests: XCTestCase {
             ).rawValue,
             "a and b"
         )
+        XCTAssertEqual(
+            Expression.cast(operation: .real(expression: .variable(name: aname))).rawValue, "real(a)"
+        )
     }
 
     /// Test init successfully creates `Expression` for simple statements.
@@ -430,6 +433,47 @@ final class ExpressionTests: XCTestCase {
                 lhs: .precedence(value: .logical(operation: .and(lhs: b, rhs: c))),
                 rhs: .logical(operation: .not(value: d))
             ))))
+        )
+    }
+
+    /// Test init for cast expressions.
+    func testCastInit() {
+        let a = Expression.variable(name: aname)
+        let b = Expression.variable(name: bname)
+        // let c = Expression.variable(name: cname)
+        // let d = Expression.variable(name: dname)
+        XCTAssertEqual(Expression(rawValue: "real(a)"), .cast(operation: .real(expression: a)))
+        XCTAssertEqual(
+            Expression(rawValue: "(real(a))"), .precedence(value: .cast(operation: .real(expression: a)))
+        )
+        XCTAssertEqual(
+            Expression(rawValue: "real(a) + 5.0"),
+            .binary(operation: .addition(
+                lhs: .cast(operation: .real(expression: a)), rhs: .literal(value: .decimal(value: 5.0))
+            ))
+        )
+        XCTAssertEqual(
+            Expression(rawValue: "real(a) + (b - 5.0)"),
+            .binary(operation: .addition(
+                lhs: .cast(operation: .real(expression: a)),
+                rhs: .precedence(value: .binary(
+                    operation: .subtraction(lhs: b, rhs: .literal(value: .decimal(value: 5.0)))
+                ))
+            ))
+        )
+        XCTAssertEqual(
+            Expression(rawValue: "(b - real(a)) + 5.0"),
+            .binary(operation: .addition(
+                lhs: .precedence(value: .binary(operation: .subtraction(
+                    lhs: b,
+                    rhs: .cast(operation: .real(expression: a))
+                ))),
+                rhs: .literal(value: .decimal(value: 5.0))
+            ))
+        )
+        XCTAssertEqual(
+            Expression(rawValue: "real(a + b)"),
+            .cast(operation: .real(expression: .binary(operation: .addition(lhs: a, rhs: b))))
         )
     }
 


### PR DESCRIPTION
This PR allows the parser to detect and generate VHDL code that performs casting operations. These casts support all current types within the `SignalType` enum.