### PR TITLE
Add the ability to parse VHDL packages.

### DIFF
--- a/Sources/VHDLParsing/VHDLPackage.swift
+++ b/Sources/VHDLParsing/VHDLPackage.swift
@@ -1,0 +1,187 @@
+// Package.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+public struct VHDLPackage: RawRepresentable, Equatable, Hashable, Codable, Sendable {
+
+    public let name: VariableName
+
+    public let statements: [HeadStatement]
+
+    public var rawValue: String {
+        """
+        package \(name.rawValue) is
+        \(statements.map { $0.rawValue }.joined(separator: "\n").indent(amount: 1))
+        end package \(name.rawValue);
+        """
+    }
+
+    public init(name: VariableName, statements: [HeadStatement]) {
+        self.name = name
+        self.statements = statements
+    }
+
+    public init?(rawValue: String) {
+        let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedString.hasSuffix(";") else {
+            return nil
+        }
+        let data = trimmedString.dropLast().trimmingCharacters(in: .whitespacesAndNewlines)
+        let words = data.words
+        guard
+            words.count >= 3,
+            words[0].lowercased() == "package",
+            words[2].lowercased() == "is",
+            let name = VariableName(rawValue: words[1]),
+            let isEndIndex = data.indexes(for: ["is"]).first?.1
+        else {
+            return nil
+        }
+        let remaining = data[isEndIndex...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard remaining.lastWord?.lowercased() == words[1].lowercased() else {
+            return nil
+        }
+        let withoutName = remaining.dropLast(words[1].count).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard withoutName.lastWord?.lowercased() == "package" else {
+            return nil
+        }
+        let withoutPackage = withoutName.dropLast("package".count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard withoutPackage.lastWord?.lowercased() == "end" else {
+            return nil
+        }
+        let withoutEnd = withoutPackage.dropLast("end".count).trimmingCharacters(in: .whitespacesAndNewlines)
+        self.init(name: name, data: withoutEnd)
+    }
+
+    init?(name: VariableName, data: String, carry: [HeadStatement] = []) {
+        let firstWord = data.firstWord?.lowercased()
+        switch firstWord {
+        case "type":
+            let words = data.words
+            if words.count >= 4, words[3].lowercased() != "record" {
+                self.init(name: name, line: data, carry: carry)
+            } else {
+                self.init(name: name, block: data, carry: carry)
+            }
+        default:
+            self.init(name: name, line: data, carry: carry)
+        }
+    }
+
+    init?(name: VariableName, block data: String, carry: [HeadStatement] = []) {
+        let words = data.words
+        guard words.count >= 2 else {
+            return nil
+        }
+        let typeName = words[1]
+        let blockWords = ["record"]
+        let indexes = blockWords.compactMap {
+            data.indexes(for: ["end", $0, typeName + ";"]).first?.1
+        }
+        guard let endIndex = indexes.min() else {
+            return nil
+        }
+        guard let statement = HeadStatement(rawValue: String(data[..<endIndex])) else {
+            return nil
+        }
+        guard data.endIndex > endIndex else {
+            self.init(name: name, statements: carry + [statement])
+            return
+        }
+        let remaining = data[endIndex...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !remaining.isEmpty else {
+            self.init(name: name, statements: carry + [statement])
+            return
+        }
+        self.init(name: name, data: remaining, carry: carry + [statement])
+    }
+
+    init?(name: VariableName, line data: String, carry: [HeadStatement] = []) {
+        if data.hasPrefix("--") {
+            guard let newLineIndex = data.firstIndex(of: "\n") else {
+                guard let statement = HeadStatement(rawValue: data) else {
+                    return nil
+                }
+                self.init(name: name, statements: carry + [statement])
+                return
+            }
+            let endIndex = data.index(after: newLineIndex)
+            guard let statement = HeadStatement(rawValue: String(data[..<newLineIndex])) else {
+                return nil
+            }
+            let remaining = data[endIndex...].trimmingCharacters(in: .whitespacesAndNewlines)
+            self.init(name: name, data: remaining, carry: carry + [statement])
+            return
+        }
+        let raw = data.uptoSemicolon
+        guard let statement = HeadStatement(rawValue: raw + ";") else {
+            return nil
+        }
+        guard let nextIndex = data.index(
+            data.startIndex, offsetBy: raw.count + 2, limitedBy: data.endIndex
+        ) else {
+            self.init(name: name, statements: carry + [statement])
+            return
+        }
+        let remaining = data[nextIndex...].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !remaining.isEmpty else {
+            self.init(name: name, statements: carry + [statement])
+            return
+        }
+        self.init(name: name, data: remaining, carry: carry + [statement])
+    }
+
+}

--- a/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
+++ b/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
@@ -78,3 +78,4 @@
 - ``Entity``
 - ``Include``
 - ``VHDLFile``
+- ``VHDLPackage``

--- a/Tests/VHDLParsingTests/VHDLFileTests.swift
+++ b/Tests/VHDLParsingTests/VHDLFileTests.swift
@@ -57,6 +57,8 @@
 @testable import VHDLParsing
 import XCTest
 
+// swiftlint:disable type_body_length
+
 /// Test class for ``VHDLFile``.
 final class VHDLFileTests: XCTestCase {
 
@@ -110,13 +112,47 @@ final class VHDLFileTests: XCTestCase {
         )
     ]
 
+    // swiftlint:disable force_unwrapping
+
+    /// The packages.
+    let packages = [
+        VHDLPackage(
+            name: VariableName(text: "Package1"),
+            statements: [
+                .definition(value: .constant(value: ConstantSignal(
+                    name: VariableName(text: "high"),
+                    type: .stdLogic,
+                    value: .literal(value: .bit(value: .high))
+                )!)),
+                .definition(value: .type(value: .record(
+                    value: Record(name: VariableName(text: "Record1_t"), types: [
+                        RecordTypeDeclaration(name: VariableName(text: "a"), type: .signal(type: .stdLogic)),
+                        RecordTypeDeclaration(name: VariableName(text: "b"), type: .signal(type: .stdLogic))
+                    ])
+                ))),
+                .definition(value: .type(value: .alias(
+                    name: VariableName(text: "xs"),
+                    type: .ranged(type: .stdLogicVector(size: .downto(
+                        upper: .literal(value: .integer(value: 3)), lower: .literal(value: .integer(value: 0))
+                    )))
+                )))
+            ]
+        )
+    ]
+
+    // swiftlint:enable force_unwrapping
+
     /// The file under test.
-    lazy var file = VHDLFile(architectures: architectures, entities: entities, includes: includes)
+    lazy var file = VHDLFile(
+        architectures: architectures, entities: entities, includes: includes, packages: packages
+    )
 
     /// Initialise the uut before every test.
     override func setUp() {
         super.setUp()
-        file = VHDLFile(architectures: architectures, entities: entities, includes: includes)
+        file = VHDLFile(
+            architectures: architectures, entities: entities, includes: includes, packages: packages
+        )
     }
 
     /// Test init sets stored properties correctly.
@@ -124,6 +160,7 @@ final class VHDLFileTests: XCTestCase {
         XCTAssertEqual(file.includes, includes)
         XCTAssertEqual(file.entities, entities)
         XCTAssertEqual(file.architectures, architectures)
+        XCTAssertEqual(file.packages, packages)
     }
 
     /// Test that `rawValue` generates the `VHDL` code correctly.
@@ -149,6 +186,15 @@ final class VHDLFileTests: XCTestCase {
                 end if;
             end process;
         end Behavioral;
+
+        package Package1 is
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
 
         """
         XCTAssertEqual(file.rawValue, expected)
@@ -177,6 +223,15 @@ final class VHDLFileTests: XCTestCase {
                 end if;
             end process;
         end Behavioral;
+
+        package Package1 is
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
 
         """
         XCTAssertEqual(VHDLFile(rawValue: raw), file)
@@ -222,6 +277,8 @@ final class VHDLFileTests: XCTestCase {
         endTestEntity;
         """
         XCTAssertNil(VHDLFile(rawValue: raw4))
+        XCTAssertNil(VHDLFile(rawValue: ""))
+        XCTAssertNil(VHDLFile(rawValue: "abc"))
     }
 
     // swiftlint:disable function_body_length
@@ -356,4 +413,85 @@ final class VHDLFileTests: XCTestCase {
         XCTAssertEqual(VHDLFile(rawValue: raw)?.rawValue, raw)
     }
 
+    /// Test package init.
+    func testInitWithPackage() {
+        let raw = """
+        package Package1 is
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertEqual(
+            VHDLFile(rawValue: raw),
+            VHDLFile(architectures: [], entities: [], includes: [], packages: packages)
+        )
+        let raw2 = """
+        package Package1 is
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+
+        package Package2 is
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package2;
+        """
+        let newPackage = VHDLPackage(name: VariableName(text: "Package2"), statements: packages[0].statements)
+        XCTAssertEqual(
+            VHDLFile(rawValue: raw2),
+            VHDLFile(architectures: [], entities: [], includes: [], packages: packages + [newPackage])
+        )
+    }
+
+    /// Test invalid package init.
+    func testInvalidPackageInit() {
+        let raw3 = """
+        package Package1 iss
+            constant high: std_logic := '1';
+            type Record1_t iss record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs iss std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertNil(VHDLFile(rawValue: raw3))
+        let raw4 = """
+        package 2Package1 is
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package 2Package1;
+        """
+        XCTAssertNil(VHDLFile(rawValue: raw4))
+        let raw5 = """
+        package Package1 iss
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertNil(VHDLFile(rawValue: raw5))
+    }
+
 }
+
+// swiftlint:enable type_body_length

--- a/Tests/VHDLParsingTests/VHDLFileTests.swift
+++ b/Tests/VHDLParsingTests/VHDLFileTests.swift
@@ -453,6 +453,7 @@ final class VHDLFileTests: XCTestCase {
             VHDLFile(rawValue: raw2),
             VHDLFile(architectures: [], entities: [], includes: [], packages: packages + [newPackage])
         )
+        XCTAssertEqual(VHDLFile(rawValue: raw2)?.rawValue, raw2 + "\n")
     }
 
     /// Test invalid package init.

--- a/Tests/VHDLParsingTests/VHDLPackageTests.swift
+++ b/Tests/VHDLParsingTests/VHDLPackageTests.swift
@@ -286,6 +286,7 @@ final class VHDLPackageTests: XCTestCase {
 
         """
         XCTAssertEqual(VHDLPackage(name: packageName, block: raw4), expected)
+        XCTAssertNil(VHDLPackage(name: packageName, block: ""))
     }
 
     /// Test line init.
@@ -295,6 +296,7 @@ final class VHDLPackageTests: XCTestCase {
             VHDLPackage(name: packageName, line: "type xs is std_logic_vector(3 downto 0);    "),
             VHDLPackage(name: packageName, statements: [statements[3]])
         )
+        XCTAssertNil(VHDLPackage(name: packageName, line: ""))
     }
 
 }

--- a/Tests/VHDLParsingTests/VHDLPackageTests.swift
+++ b/Tests/VHDLParsingTests/VHDLPackageTests.swift
@@ -131,6 +131,170 @@ final class VHDLPackageTests: XCTestCase {
         end package Package1;
         """
         XCTAssertEqual(VHDLPackage(rawValue: raw), package)
+        let raw2 = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t; type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertEqual(VHDLPackage(rawValue: raw2), package)
+        let raw3 = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1'; type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertEqual(VHDLPackage(rawValue: raw3), package)
+        let raw4 = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+            -- Statements
+        end package Package1;
+        """
+        let newPackage = VHDLPackage(name: packageName, statements: statements + [statements[0]])
+        XCTAssertEqual(VHDLPackage(rawValue: raw4), newPackage)
+    }
+
+    /// Test `init(rawValue:)` for invalid package definition.
+    func testInvalidRawValueInit() {
+        let raw = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1
+        """
+        XCTAssertNil(VHDLPackage(rawValue: raw))
+        let raw2 = """
+        packages Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertNil(VHDLPackage(rawValue: raw2))
+        let raw3 = """
+        package Package12 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertNil(VHDLPackage(rawValue: raw3))
+        let raw4 = """
+        package 2Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package 2Package1;
+        """
+        XCTAssertNil(VHDLPackage(rawValue: raw4))
+        XCTAssertNil(VHDLPackage(rawValue: ""))
+    }
+
+    /// Test `init(rawValue:)` for invalid package definition.
+    func testInvalidRawValueInit2() {
+        let raw5 = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end packages Package1;
+        """
+        XCTAssertNil(VHDLPackage(rawValue: raw5))
+        let raw6 = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        ends package Package1;
+        """
+        XCTAssertNil(VHDLPackage(rawValue: raw6))
+    }
+
+    /// Test block init.
+    func testBlockInit() {
+        XCTAssertNil(VHDLPackage(name: packageName, block: "type"))
+        XCTAssertNil(VHDLPackage(name: packageName, block: "type Record1_t is record"))
+        let raw = """
+        type Record1_t is record
+            a: std_logic;
+            b: std_logic
+        end record Record1_t;
+        """
+        XCTAssertNil(VHDLPackage(name: packageName, block: raw))
+        let raw2 = """
+        package Package1 is
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+        end package Package1;
+        """
+        let expected = VHDLPackage(name: packageName, statements: [statements[2]])
+        XCTAssertEqual(VHDLPackage(rawValue: raw2), expected)
+        let raw3 = """
+        type Record1_t is record
+            a: std_logic;
+            b: std_logic;
+        end record Record1_t;
+        """
+        XCTAssertEqual(VHDLPackage(name: packageName, block: raw3), expected)
+        let raw4 = """
+        type Record1_t is record
+            a: std_logic;
+            b: std_logic;
+        end record Record1_t;
+
+        """
+        XCTAssertEqual(VHDLPackage(name: packageName, block: raw4), expected)
+    }
+
+    /// Test line init.
+    func testLineInit() {
+        XCTAssertNil(VHDLPackage(name: packageName, line: "2x: std_logic;"))
+        XCTAssertEqual(
+            VHDLPackage(name: packageName, line: "type xs is std_logic_vector(3 downto 0);    "),
+            VHDLPackage(name: packageName, statements: [statements[3]])
+        )
     }
 
 }

--- a/Tests/VHDLParsingTests/VHDLPackageTests.swift
+++ b/Tests/VHDLParsingTests/VHDLPackageTests.swift
@@ -1,0 +1,136 @@
+// VHDLPackageTests.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLParsing
+import XCTest
+
+/// Test class for ``VHDLPackage``.
+final class VHDLPackageTests: XCTestCase {
+
+    /// The package name.
+    let packageName = VariableName(text: "Package1")
+
+    // swiftlint:disable force_unwrapping
+
+    /// The package statements.
+    let statements = [
+        HeadStatement.comment(value: Comment(text: "Statements")),
+        .definition(value: .constant(value: ConstantSignal(
+            name: VariableName(text: "high"), type: .stdLogic, value: .literal(value: .bit(value: .high))
+        )!)),
+        .definition(value: .type(value: .record(
+            value: Record(name: VariableName(text: "Record1_t"), types: [
+                RecordTypeDeclaration(name: VariableName(text: "a"), type: .signal(type: .stdLogic)),
+                RecordTypeDeclaration(name: VariableName(text: "b"), type: .signal(type: .stdLogic))
+            ])
+        ))),
+        .definition(value: .type(value: .alias(
+            name: VariableName(text: "xs"),
+            type: .ranged(type: .stdLogicVector(size: .downto(
+                upper: .literal(value: .integer(value: 3)), lower: .literal(value: .integer(value: 0))
+            )))
+        )))
+    ]
+
+    // swiftlint:enable force_unwrapping
+
+    /// The package under test.
+    lazy var package = VHDLPackage(name: packageName, statements: statements)
+
+    /// Initialise the package under test.
+    override func setUp() {
+        package = VHDLPackage(name: packageName, statements: statements)
+    }
+
+    /// Test that the stored properties are set correctly.
+    func testInit() {
+        XCTAssertEqual(package.name, packageName)
+        XCTAssertEqual(package.statements, statements)
+    }
+
+    /// Test that the `VHDL` code is generated correctly.
+    func testRawValue() {
+        let expected = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertEqual(package.rawValue, expected)
+    }
+
+    /// Test that `init(rawValue:)` parses the `VHDL` code correctly.
+    func testRawValueInit() {
+        let raw = """
+        package Package1 is
+            -- Statements
+            constant high: std_logic := '1';
+            type Record1_t is record
+                a: std_logic;
+                b: std_logic;
+            end record Record1_t;
+            type xs is std_logic_vector(3 downto 0);
+        end package Package1;
+        """
+        XCTAssertEqual(VHDLPackage(rawValue: raw), package)
+    }
+
+}


### PR DESCRIPTION
This PR adds the ability to parse `VHDL` packages. The `VHDLFile` struct is altered to contain a stored property for the packages within the file:

```swift
public struct VHDLFile {

    let packages: [VHDLPackage]

}
```

This PR does not support defining package bodies since functions are still not supported in this parser.