### PR TITLE
Add true and false to reserved words.

### DIFF
--- a/Sources/StringHelpers/Set+VHDLReservedWords.swift
+++ b/Sources/StringHelpers/Set+VHDLReservedWords.swift
@@ -90,14 +90,14 @@ public extension Set where Element == String {
             "abs", "access", "after", "alias", "all", "and", "architecture", "array",
             "assert", "attribute", "begin", "block", "body", "buffer", "bus", "case",
             "component", "configuration", "constant", "disconnect", "downto", "else",
-            "elsif", "end", "entity", "exit", "file", "for", "function", "generate",
+            "elsif", "end", "entity", "exit", "false", "file", "for", "function", "generate",
             "generic", "group", "guarded", "if", "impure", "in", "inertial", "inout",
             "is", "label", "library", "linkage", "literal", "loop", "map", "mod", "nand",
             "new", "next", "nor", "not", "null", "of", "on", "open", "or", "others",
             "out", "package", "port", "postponed", "procedure", "process", "pure",
             "range", "record", "register", "reject", "return", "rol", "ror", "select",
             "severity", "signal", "shared", "sla", "sli", "sra", "srl", "subtype",
-            "then", "to", "transport", "type", "unaffected", "units", "until", "use",
+            "then", "to", "transport", "true", "type", "unaffected", "units", "until", "use",
             "variable", "wait", "when", "while", "with", "xnor", "xor"
         ]
     }

--- a/Sources/VHDLParsing/VariableName.swift
+++ b/Sources/VHDLParsing/VariableName.swift
@@ -91,7 +91,7 @@ public struct VariableName: RawRepresentable,
             let firstChar = trimmedName.unicodeScalars.first,
             CharacterSet.letters.contains(firstChar),
             trimmedName.unicodeScalars.allSatisfy({ allowedChars.contains($0) }),
-            !Set<String>.vhdlAllReservedWords.contains(trimmedName)
+            !Set<String>.vhdlAllReservedWords.contains(trimmedName.lowercased())
         else {
             return nil
         }

--- a/Tests/VHDLParsingTests/VariableNameTests.swift
+++ b/Tests/VHDLParsingTests/VariableNameTests.swift
@@ -115,6 +115,8 @@ final class VariableNameTests: XCTestCase {
         XCTAssertNil(VariableName(rawValue: "xor"))
         XCTAssertNil(VariableName(rawValue: "clk 12"))
         XCTAssertEqual(VariableName(rawValue: "x "), VariableName(text: "x"))
+        XCTAssertNil(VariableName(rawValue: "false"))
+        XCTAssertNil(VariableName(rawValue: "true"))
     }
 
 }

--- a/Tests/VHDLParsingTests/VariableNameTests.swift
+++ b/Tests/VHDLParsingTests/VariableNameTests.swift
@@ -117,6 +117,8 @@ final class VariableNameTests: XCTestCase {
         XCTAssertEqual(VariableName(rawValue: "x "), VariableName(text: "x"))
         XCTAssertNil(VariableName(rawValue: "false"))
         XCTAssertNil(VariableName(rawValue: "true"))
+        XCTAssertNil(VariableName(rawValue: "FALSE"))
+        XCTAssertNil(VariableName(rawValue: "TRUE"))
     }
 
 }


### PR DESCRIPTION
Adds `true` and `false` to reserved words in VHDL. This change disallows `true` and `false` to be used in `VariableName` initialisers.