### PR TITLE
Add missing imports and change PortSignal to use Type.

### DIFF
--- a/Sources/StringHelpers/CharacterSet+VHDLSets.swift
+++ b/Sources/StringHelpers/CharacterSet+VHDLSets.swift
@@ -60,34 +60,22 @@ import Foundation
 extension CharacterSet {
 
     /// The allowed characters for `VHDL` variable names.
-    @inlinable public static var variableNames: CharacterSet {
-        CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
-    }
+    public static let variableNames = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
 
     /// The VHDL operators with additive precedence.
-    @inlinable public static var vhdlAdditiveOperations: CharacterSet {
-        CharacterSet(charactersIn: "+-")
-    }
+    public static let vhdlAdditiveOperations = CharacterSet(charactersIn: "+-")
 
     /// The `VHDL` comparison operators (<, >, =).
-    @inlinable public static var vhdlComparisonOperations: CharacterSet {
-        CharacterSet(charactersIn: "=<>")
-    }
+    public static let vhdlComparisonOperations = CharacterSet(charactersIn: "=<>")
 
     /// The VHDL operators with multiplicative precedence.
-    @inlinable public static var vhdlMultiplicativeOperations: CharacterSet {
-        CharacterSet(charactersIn: "*/")
-    }
+    public static let vhdlMultiplicativeOperations = CharacterSet(charactersIn: "*/")
 
     /// All VHDL operators.
-    @inlinable public static var vhdlOperators: CharacterSet {
-        CharacterSet(charactersIn: "+-/*()")
-    }
+    public static let vhdlOperators = CharacterSet(charactersIn: "+-/*()")
 
     /// The VHDL binary operators.
-    @inlinable public static var vhdlOperations: CharacterSet {
-        CharacterSet(charactersIn: "+-/*")
-    }
+    public static let vhdlOperations = CharacterSet(charactersIn: "+-/*")
 
     /// Whether a string contains characters in this character set.
     /// - Parameter string: The string to check.

--- a/Sources/StringHelpers/Set+VHDLReservedWords.swift
+++ b/Sources/StringHelpers/Set+VHDLReservedWords.swift
@@ -57,23 +57,53 @@
 /// Add VHDL reserved words Sets.
 public extension Set where Element == String {
 
+    /// The boolean operations requiring two operands in `VHDL`.
+    static let vhdlBooleanBinaryOperations: Set<String> = [
+        "and", "or", "nand", "nor", "xor", "xnor"
+    ]
+
+    /// The comparison operators supported in `VHDL`.
+    static let vhdlComparisonOperations: Set<String> = [
+        ">", "<", "<=", ">=", "=", "/="
+    ]
+
+    /// The `VHDL` reserved words not including the `VHDL` signal types. If you need both, then use
+    /// `Set<String>.vhdlAllReservedWords`.
+    static let vhdlReservedWords: Set<String> = [
+        "abs", "access", "after", "alias", "all", "and", "architecture", "array",
+        "assert", "attribute", "begin", "block", "body", "buffer", "bus", "case",
+        "component", "configuration", "constant", "disconnect", "downto", "else",
+        "elsif", "end", "entity", "exit", "false", "file", "for", "function", "generate",
+        "generic", "group", "guarded", "if", "impure", "in", "inertial", "inout",
+        "is", "label", "library", "linkage", "literal", "loop", "map", "mod", "nand",
+        "new", "next", "nor", "not", "null", "of", "on", "open", "or", "others",
+        "out", "package", "port", "postponed", "procedure", "process", "pure",
+        "range", "record", "register", "reject", "return", "rol", "ror", "select",
+        "severity", "signal", "shared", "sla", "sli", "sra", "srl", "subtype",
+        "then", "to", "transport", "true", "type", "unaffected", "units", "until", "use",
+        "variable", "wait", "when", "while", "with", "xnor", "xor"
+    ]
+
+    /// The `VHDL` signal types.
+    static let vhdlSignalTypes: Set<String> = [
+        "std_logic",
+        "std_ulogic",
+        "signed",
+        "unsigned",
+        "std_logic_vector",
+        "std_ulogic_vector",
+        "bit",
+        "bit_vector",
+        "boolean",
+        "integer",
+        "natural",
+        "positive",
+        "real"
+    ]
+
     /// All `VHDL` reserved words including the `VHDL` signal types.
     @inlinable static var vhdlAllReservedWords: Set<String> {
         Self.vhdlSignalTypes.union(Self.vhdlReservedWords)
-    }
-
-    /// The boolean operations requiring two operands in `VHDL`.
-    @inlinable static var vhdlBooleanBinaryOperations: Set<String> {
-        [
-            "and", "or", "nand", "nor", "xor", "xnor"
-        ]
-    }
-
-    /// The comparison operators supported in `VHDL`.
-    @inlinable static var vhdlComparisonOperations: Set<String> {
-        [
-            ">", "<", "<=", ">=", "=", "/="
-        ]
     }
 
     /// All operators supported in `VHDL`.
@@ -81,44 +111,6 @@ public extension Set where Element == String {
         Set([
             ">", "<", "<=", ">=", "=", "/=", "+", "-", "/", "*"
         ]).union(Set<String>.vhdlBooleanBinaryOperations)
-    }
-
-    /// The `VHDL` reserved words not including the `VHDL` signal types. If you need both, then use
-    /// `Set<String>.vhdlAllReservedWords`.
-    @inlinable static var vhdlReservedWords: Set<String> {
-        [
-            "abs", "access", "after", "alias", "all", "and", "architecture", "array",
-            "assert", "attribute", "begin", "block", "body", "buffer", "bus", "case",
-            "component", "configuration", "constant", "disconnect", "downto", "else",
-            "elsif", "end", "entity", "exit", "false", "file", "for", "function", "generate",
-            "generic", "group", "guarded", "if", "impure", "in", "inertial", "inout",
-            "is", "label", "library", "linkage", "literal", "loop", "map", "mod", "nand",
-            "new", "next", "nor", "not", "null", "of", "on", "open", "or", "others",
-            "out", "package", "port", "postponed", "procedure", "process", "pure",
-            "range", "record", "register", "reject", "return", "rol", "ror", "select",
-            "severity", "signal", "shared", "sla", "sli", "sra", "srl", "subtype",
-            "then", "to", "transport", "true", "type", "unaffected", "units", "until", "use",
-            "variable", "wait", "when", "while", "with", "xnor", "xor"
-        ]
-    }
-
-    /// The `VHDL` signal types.
-    @inlinable static var vhdlSignalTypes: Set<String> {
-        [
-            "std_logic",
-            "std_ulogic",
-            "signed",
-            "unsigned",
-            "std_logic_vector",
-            "std_ulogic_vector",
-            "bit",
-            "bit_vector",
-            "boolean",
-            "integer",
-            "natural",
-            "positive",
-            "real"
-        ]
     }
 
 }

--- a/Sources/StringHelpers/String+VHDLMethods.swift
+++ b/Sources/StringHelpers/String+VHDLMethods.swift
@@ -63,12 +63,12 @@ extension String {
     public static let tab = "    "
 
     /// A `VHDL` null block in a case statement.
-    @inlinable public static var nullBlock: String {
+    public static let nullBlock = {
         """
         when others =>
         \(String.tab)null;
         """
-    }
+    }()
 
     /// Get the first word in the string.
     @inlinable public var firstWord: String? {

--- a/Sources/VHDLParsing/Architecture.swift
+++ b/Sources/VHDLParsing/Architecture.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// An architecture block in `VHDL`.
 public struct Architecture: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/ArrayDefinition.swift
+++ b/Sources/VHDLParsing/ArrayDefinition.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// Definition of a new array type.
 public struct ArrayDefinition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/BitLiteral.swift
+++ b/Sources/VHDLParsing/BitLiteral.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// Type for expressing single-bit bit values in *VHDL*.
 public enum BitLiteral: String, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/BitVector.swift
+++ b/Sources/VHDLParsing/BitVector.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A ``VectorLiteral`` of ``BitLiteral`` values.
 public struct BitVector: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/CaseStatement.swift
+++ b/Sources/VHDLParsing/CaseStatement.swift
@@ -54,6 +54,7 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
 import StringHelpers
 
 /// A struct that represents a `case` statement in `VHDL`.

--- a/Sources/VHDLParsing/CastOperation.swift
+++ b/Sources/VHDLParsing/CastOperation.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import StringHelpers
+
 /// A cast operation converting an expression to a specific ``SignalType``.
 public enum CastOperation: FunctionCallable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/Comment.swift
+++ b/Sources/VHDLParsing/Comment.swift
@@ -55,6 +55,7 @@
 // 
 
 import Foundation
+import StringHelpers
 
 /// A single-lined VHDL comment.
 public struct Comment: RawRepresentable, CustomStringConvertible, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/ComparisonOperation.swift
+++ b/Sources/VHDLParsing/ComparisonOperation.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A type for representing VHDL comparison operations. These operations exist within a
 /// ``ConditionalExpression``. The supported operations are:
 /// - Less than (operation <).

--- a/Sources/VHDLParsing/ComponentDefinition.swift
+++ b/Sources/VHDLParsing/ComponentDefinition.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A definition of a `VHDL` component that can be instantiated in the architecture body.
 public struct ComponentDefinition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/ComponentInstantiation.swift
+++ b/Sources/VHDLParsing/ComponentInstantiation.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A component instantiation in `VHDL`. This struct represents a component that is instantiated using a
 /// `port map` and optionally a `generic map`.
 public struct ComponentInstantiation: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/ConditionalExpression.swift
+++ b/Sources/VHDLParsing/ConditionalExpression.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A type for representing expression that can be used in a conditional statement.
 public enum ConditionalExpression: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/ConstantSignal.swift
+++ b/Sources/VHDLParsing/ConstantSignal.swift
@@ -55,6 +55,7 @@
 // 
 
 import Foundation
+import StringHelpers
 
 /// A type representing a valid constant declaration in `VHDL`.
 public struct ConstantSignal: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/Definition.swift
+++ b/Sources/VHDLParsing/Definition.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A definition of a new variable in `VHDL`.
 public enum Definition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/EdgeCondition.swift
+++ b/Sources/VHDLParsing/EdgeCondition.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A ``ConditionalExpression`` that checks for the presence of a clocks edge. This type represents
 /// the `rising_edge` and `falling_edge` functions in `VHDL`.
 public enum EdgeCondition: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/Entity.swift
+++ b/Sources/VHDLParsing/Entity.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A `VHDL` entity statement.
 public struct Entity: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/Expression.swift
+++ b/Sources/VHDLParsing/Expression.swift
@@ -55,6 +55,7 @@
 // 
 
 import Foundation
+import StringHelpers
 
 /// An `Expression` represents a stand-alone statement that resolves to some value in `VHDL`. Typical
 /// expressions would include all operations after the `<=` symbol in a `VHDL` assignment operation. Some

--- a/Sources/VHDLParsing/ForLoop.swift
+++ b/Sources/VHDLParsing/ForLoop.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A structure for definine *synchronous* for loops. These are for loops that exist within a process block.
 public struct ForLoop: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/FunctionCall.swift
+++ b/Sources/VHDLParsing/FunctionCall.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// This type represents `VHDL` code that is enacting a function call.
 public enum FunctionCall: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/FunctionCallable.swift
+++ b/Sources/VHDLParsing/FunctionCallable.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// Helper protocol for defining types that can be executed as a function call.
 public protocol FunctionCallable: RawRepresentable {
 

--- a/Sources/VHDLParsing/GenericBlock.swift
+++ b/Sources/VHDLParsing/GenericBlock.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A struct for representing generic declarations in an entity/component block.
 public struct GenericBlock: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/GenericMap.swift
+++ b/Sources/VHDLParsing/GenericMap.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A `generic map` in `VHDL`. This is used to map generic variables to their values in a component.
 public struct GenericMap: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/GenericTypeDeclaration.swift
+++ b/Sources/VHDLParsing/GenericTypeDeclaration.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A type representing a generic type declaration inside a generic block in `VHDL`. This struct parses and
 /// represents individual generic types within an entity.
 public struct GenericTypeDeclaration: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/GenericVariableMap.swift
+++ b/Sources/VHDLParsing/GenericVariableMap.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// An operation that maps 2 generics together. This operation is used in generic maps for components.
 public struct GenericVariableMap: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/HexVector.swift
+++ b/Sources/VHDLParsing/HexVector.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A literal string that represents hexadecimal values for assignment into a vector in `VHDL`.
 public struct HexVector: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/IfBlock.swift
+++ b/Sources/VHDLParsing/IfBlock.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// This type is used to represent an if-statement in `VHDL`. The if-statement may contain nested
 /// if-statements or `elsif` conditions.
 public enum IfBlock: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/Include.swift
+++ b/Sources/VHDLParsing/Include.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A type for representing VHDL include statements.
 public enum Include: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/IndexedValue.swift
+++ b/Sources/VHDLParsing/IndexedValue.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// This type represents a value for a specific index in a vector type within `VHDL`. For example, consider a
 /// signal `x` with type `std_logic_vector(3 downto 0)`. We can assign specific bits within `x` by using the
 /// `VHDL` statement `x <= (3 => '1', others => '0');`. This statement says bit 3 of `x` should be set to 1

--- a/Sources/VHDLParsing/IndexedVector.swift
+++ b/Sources/VHDLParsing/IndexedVector.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A type for representing vector literals that assign specific bit/logic values to specific indices.
 /// This struct is used to represent `VHDL` expressions of the form `(0 => '0', 1 => '1', 2 => '0')`, etc.
 /// For example, consider a signal `x` that is a `std_logic_vector(7 downto 0)`. We may assign values to `x`

--- a/Sources/VHDLParsing/LogicLiteral.swift
+++ b/Sources/VHDLParsing/LogicLiteral.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// The possible values for a single bit logic value in `VHDL`.
 public enum LogicLiteral: String, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/LogicVector.swift
+++ b/Sources/VHDLParsing/LogicVector.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A type for representing a ``VectorLiteral`` of `std_logic` values (``LogicLiteral``).
 public struct LogicVector: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/MathRealFunctionCalls.swift
+++ b/Sources/VHDLParsing/MathRealFunctionCalls.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A function call where the function being called exists within the `math_real` package.
 public enum MathRealFunctionCalls: FunctionCallable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/OctalVector.swift
+++ b/Sources/VHDLParsing/OctalVector.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A type for representing a ``VectorLiteral`` of octal values.
 public struct OctalVector: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/PortBlock.swift
+++ b/Sources/VHDLParsing/PortBlock.swift
@@ -55,6 +55,7 @@
 // 
 
 import Foundation
+import StringHelpers
 
 /// A port statement in `VHDL`.
 public struct PortBlock: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/PortMap.swift
+++ b/Sources/VHDLParsing/PortMap.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A `port map` declaration in `VHDL`. This block represents the connections to the port signals in a
 /// component instantiation.
 public struct PortMap: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/PortSignal.swift
+++ b/Sources/VHDLParsing/PortSignal.swift
@@ -12,7 +12,7 @@ import Foundation
 public struct PortSignal: ExternalType, RawRepresentable, Codable, Hashable, Sendable {
 
     /// The type of the signal.
-    public var type: SignalType
+    public var type: Type
 
     /// The name of the signal.
     public var name: VariableName
@@ -36,9 +36,9 @@ public struct PortSignal: ExternalType, RawRepresentable, Codable, Hashable, Sen
         return declaration + " := \(defaultValue.rawValue);\(comment)"
     }
 
-    /// Initialises a new external signal with the given type, name, mode, default value and comment.
+    /// Initialises a new external signal with the given signal type, name, mode, default value and comment.
     /// - Parameters:
-    ///   - type: The type of the signal.
+    ///   - type: The ``SignalType`` of the signal.
     ///   - name: The name of the signal.
     ///   - mode: The mode of the signal.
     ///   - defaultValue: The default value of the signal.
@@ -50,6 +50,22 @@ public struct PortSignal: ExternalType, RawRepresentable, Codable, Hashable, Sen
         mode: Mode,
         defaultValue: Expression? = nil,
         comment: Comment? = nil
+    ) {
+        self.init(
+            type: .signal(type: type), name: name, mode: mode, defaultValue: defaultValue, comment: comment
+        )
+    }
+
+    /// Initialises a new external signal with the given type, name, mode, default value and comment.
+    /// - Parameters:
+    ///   - type: The type of the signal.
+    ///   - name: The name of the signal.
+    ///   - mode: The mode of the signal.
+    ///   - defaultValue: The default value of the signal.
+    ///   - comment: The comment of the signal.
+    @inlinable
+    public init(
+        type: Type, name: VariableName, mode: Mode, defaultValue: Expression? = nil, comment: Comment? = nil
     ) {
         self.type = type
         self.name = name
@@ -96,7 +112,7 @@ public struct PortSignal: ExternalType, RawRepresentable, Codable, Hashable, Sen
         }
         let nameString = hasColonComponents ? nameComponents : String(nameComponents.dropLast())
         guard
-            let name = VariableName(rawValue: nameString), let type = SignalType(rawValue: typeString)
+            let name = VariableName(rawValue: nameString), let type = Type(rawValue: typeString)
         else {
             return nil
         }

--- a/Sources/VHDLParsing/PortSignal.swift
+++ b/Sources/VHDLParsing/PortSignal.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import StringHelpers
 
 /// An external signal is equivalent to an external variable (or parameter) in an LLFSM. The external signal
 /// is a signal that exists above a VHDL entities scope. It is a signal that is not defined within the entity.

--- a/Sources/VHDLParsing/ProcessBlock.swift
+++ b/Sources/VHDLParsing/ProcessBlock.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A struct for representing a process block.
 public struct ProcessBlock: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/Record.swift
+++ b/Sources/VHDLParsing/Record.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A record type definition.
 public struct Record: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/RecordTypeDeclaration.swift
+++ b/Sources/VHDLParsing/RecordTypeDeclaration.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A struct for representing variables defined within a record.
 public struct RecordTypeDeclaration: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/SignalLiteral.swift
+++ b/Sources/VHDLParsing/SignalLiteral.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A type for representing all signal literals.
 public enum SignalLiteral: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/SignalType.swift
+++ b/Sources/VHDLParsing/SignalType.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// Valid VHDL Signal types.
 public enum SignalType: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/Statement.swift
+++ b/Sources/VHDLParsing/Statement.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A statement is a a full operation that contains expressions that resolve to some value or logic that is
 /// performed. A statement may be definitions, assignments to variables or comments.
 public enum Statement: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/TypeDefinition.swift
+++ b/Sources/VHDLParsing/TypeDefinition.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A definition of a custom type.
 public enum TypeDefinition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/VHDLFile.swift
+++ b/Sources/VHDLParsing/VHDLFile.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A file containing `VHDL` code.
 public struct VHDLFile: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/VHDLPackage.swift
+++ b/Sources/VHDLParsing/VHDLPackage.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A struct representing a package definition in `VHDL`. This struct does not represent the body definition,
 /// i.e. using `package body <name> is` in `VHDL`.
 public struct VHDLPackage: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/VariableAssignment.swift
+++ b/Sources/VHDLParsing/VariableAssignment.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A variable assignment exists within a port map and is used to assign a port to a variable. This enum
 /// also contains the `open` case in `VHDL` that is valid for port signals.
 public enum VariableAssignment: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/VariableMap.swift
+++ b/Sources/VHDLParsing/VariableMap.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// An operation that maps 2 signals together. This operation is used in generic maps or port maps for
 /// components.
 public struct VariableMap: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/VariableName.swift
+++ b/Sources/VHDLParsing/VariableName.swift
@@ -55,6 +55,7 @@
 // 
 
 import Foundation
+import StringHelpers
 
 /// Valid VHDL variable names. This struct represents a valid VHDL variable name. It is impossible to create
 /// an invalid name using the public interface of this struct.

--- a/Sources/VHDLParsing/VariableReference.swift
+++ b/Sources/VHDLParsing/VariableReference.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A type for defining types of references to a variable.
 public enum VariableReference: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Sources/VHDLParsing/VectorIndex.swift
+++ b/Sources/VHDLParsing/VectorIndex.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// An index of a vector in `VHDL`. This type is designed to represent indexes in an assignment statement for
 /// a vector type. For example, you may have a signal `x` of type `std_logic_vector(7 downto 0)` that you
 /// want to assign a value to. In `VHDL`, you can do this with the statement `x <= (others => '0');`.

--- a/Sources/VHDLParsing/VectorLiteral.swift
+++ b/Sources/VHDLParsing/VectorLiteral.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A vector literal is a string of bits, hexademical digits, or octal digits. This enum allows VHDL signal
 /// literal values to be represented.
 public enum VectorLiteral: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/VectorSize.swift
+++ b/Sources/VHDLParsing/VectorSize.swift
@@ -54,6 +54,8 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
 /// A type for representing VHDL vector sizes. This type is equivalent to the `range` of a VHDL vector type,
 /// e.g. *5 downto 3* or *3 to 5*.
 public enum VectorSize: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/WhenCase.swift
+++ b/Sources/VHDLParsing/WhenCase.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A single when case including the code within it. The when statement exists within a case statement and
 /// represents code that is executed under a specific condition.
 public struct WhenCase: RawRepresentable, Equatable, Hashable, Codable, Sendable {

--- a/Sources/VHDLParsing/WhenCondition.swift
+++ b/Sources/VHDLParsing/WhenCondition.swift
@@ -54,6 +54,9 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+import StringHelpers
+
 /// A condition that can be used in a `when` statement.
 public enum WhenCondition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 

--- a/Tests/VHDLParsingTests/PortSignalTests.swift
+++ b/Tests/VHDLParsingTests/PortSignalTests.swift
@@ -86,7 +86,7 @@ final class PortSignalTests: XCTestCase {
             XCTFail("Failed to create comment.")
             return
         }
-        XCTAssertEqual(self.signal.type, .stdLogic)
+        XCTAssertEqual(self.signal.type, .signal(type: .stdLogic))
         XCTAssertEqual(self.signal.name, VariableName(text: "x"))
         XCTAssertEqual(self.signal.mode, .output)
         XCTAssertEqual(self.signal.defaultValue, .literal(value: .logic(value: .high)))
@@ -99,18 +99,18 @@ final class PortSignalTests: XCTestCase {
             XCTFail("Failed to create comment.")
             return
         }
-        self.signal.type = .ranged(type: .stdLogicVector(size: .downto(
+        self.signal.type = .signal(type: .ranged(type: .stdLogicVector(size: .downto(
             upper: .literal(value: .integer(value: 7)), lower: .literal(value: .integer(value: 0))
-        )))
+        ))))
         self.signal.name = VariableName(text: "y")
         self.signal.mode = .input
         self.signal.defaultValue = .literal(
             value: .vector(value: .hexademical(value: HexVector(values: [.ten, .ten])))
         )
         self.signal.comment = comment
-        XCTAssertEqual(self.signal.type, .ranged(type: .stdLogicVector(size: .downto(
+        XCTAssertEqual(self.signal.type, .signal(type: .ranged(type: .stdLogicVector(size: .downto(
             upper: .literal(value: .integer(value: 7)), lower: .literal(value: .integer(value: 0))
-        ))))
+        )))))
         XCTAssertEqual(self.signal.name, VariableName(text: "y"))
         XCTAssertEqual(self.signal.mode, .input)
         XCTAssertEqual(
@@ -164,9 +164,9 @@ final class PortSignalTests: XCTestCase {
 
     /// Test rawValue init works for vector types.
     func testRawValueInitVectorType() {
-        signal.type = .ranged(type: .stdLogicVector(size: .downto(
+        signal.type = .signal(type: .ranged(type: .stdLogicVector(size: .downto(
             upper: .literal(value: .integer(value: 3)), lower: .literal(value: .integer(value: 0))
-        )))
+        ))))
         XCTAssertEqual(
             PortSignal(rawValue: "x: out std_logic_vector(3 downto 0) := '1'; -- signal x"), signal
         )


### PR DESCRIPTION
This PR adds missing imports that were implicitly included in previous swift versions. Under swift 5.6, this behaviour causes compilation errors so the imports have now been included in files that require them.

Change the `PortSignal` `type` property to use a `Type` instead of a `SignalType`. This change allows more advanced types to be placed in port declarations such as record types.