### PR TITLE
Make IndexedValue use Expression type as the value.

### DIFF
--- a/Sources/VHDLParsing/BinaryOperation.swift
+++ b/Sources/VHDLParsing/BinaryOperation.swift
@@ -71,6 +71,15 @@ public enum BinaryOperation: RawRepresentable, Equatable, Hashable, Codable, Sen
     /// A division operation.
     case division(lhs: Expression, rhs: Expression)
 
+    /// The left-hand side operand in this binary operation.
+    @inlinable public var lhs: Expression {
+        switch self {
+        case .addition(let lhs, _), .subtraction(let lhs, _), .division(let lhs, _),
+            .multiplication(let lhs, _):
+            return lhs
+        }
+    }
+
     /// The `VHDL` code representing this operation.
     @inlinable public var rawValue: String {
         switch self {
@@ -82,6 +91,15 @@ public enum BinaryOperation: RawRepresentable, Equatable, Hashable, Codable, Sen
             return "\(lhs.rawValue) * \(rhs.rawValue)"
         case .division(let lhs, let rhs):
             return "\(lhs.rawValue) / \(rhs.rawValue)"
+        }
+    }
+
+    /// The right-hand side operand in this binary operation.
+    @inlinable public var rhs: Expression {
+        switch self {
+        case .addition(_, let rhs), .subtraction(_, let rhs), .division(_, let rhs),
+            .multiplication(_, let rhs):
+            return rhs
         }
     }
 

--- a/Sources/VHDLParsing/IndexedVector.swift
+++ b/Sources/VHDLParsing/IndexedVector.swift
@@ -100,7 +100,10 @@ public struct IndexedVector: RawRepresentable, Equatable, Hashable, Codable, Sen
             return nil
         }
         let hasLogic = bits.contains {
-            switch $0.value {
+            guard case .literal(let literal) = $0.value else {
+                return false
+            }
+            switch literal {
             case .logic:
                 return true
             default:
@@ -108,8 +111,11 @@ public struct IndexedVector: RawRepresentable, Equatable, Hashable, Codable, Sen
             }
         }
         if hasLogic {
-            let logics = bits.compactMap {
-                switch $0.value {
+            let logics: [IndexedValue] = bits.compactMap {
+                guard case .literal(let literal) = $0.value else {
+                    return nil
+                }
+                switch literal {
                 case .logic:
                     return $0
                 case .bit(let bit):
@@ -118,9 +124,9 @@ public struct IndexedVector: RawRepresentable, Equatable, Hashable, Codable, Sen
                     return nil
                 }
             }
-            self.values = logics
+            self.init(values: logics)
         } else {
-            self.values = bits
+            self.init(values: bits)
         }
     }
 

--- a/Tests/VHDLParsingTests/BinaryOperationTests.swift
+++ b/Tests/VHDLParsingTests/BinaryOperationTests.swift
@@ -173,4 +173,20 @@ final class BinaryOperationTests: XCTestCase {
         XCTAssertNil(BinaryOperation(lhs: x, rhs: y, str: "^"))
     }
 
+    /// Test `lhs` computed property.
+    func testLHS() {
+        XCTAssertEqual(BinaryOperation.addition(lhs: x, rhs: y).lhs, x)
+        XCTAssertEqual(BinaryOperation.subtraction(lhs: x, rhs: y).lhs, x)
+        XCTAssertEqual(BinaryOperation.multiplication(lhs: x, rhs: y).lhs, x)
+        XCTAssertEqual(BinaryOperation.division(lhs: x, rhs: y).lhs, x)
+    }
+
+    /// Test `rhs` computed property.
+    func testRHS() {
+        XCTAssertEqual(BinaryOperation.addition(lhs: x, rhs: y).rhs, y)
+        XCTAssertEqual(BinaryOperation.subtraction(lhs: x, rhs: y).rhs, y)
+        XCTAssertEqual(BinaryOperation.multiplication(lhs: x, rhs: y).rhs, y)
+        XCTAssertEqual(BinaryOperation.division(lhs: x, rhs: y).rhs, y)
+    }
+
 }

--- a/Tests/VHDLParsingTests/ExpressionTests.swift
+++ b/Tests/VHDLParsingTests/ExpressionTests.swift
@@ -415,6 +415,35 @@ final class ExpressionTests: XCTestCase {
         )))
     }
 
+    /// Tests that `isValidOtherValue` correctly identifies valid other values.
+    func testIsValidOtherValue() {
+        XCTAssertTrue(Expression.binary(operation: .addition(lhs: a, rhs: b)).isValidOtherValue)
+        XCTAssertTrue(Expression.cast(operation: .bit(expression: a)).isValidOtherValue)
+        XCTAssertFalse(Expression.cast(operation: .boolean(expression: a)).isValidOtherValue)
+        XCTAssertFalse(
+            Expression.conditional(condition: .edge(value: .falling(expression: a))).isValidOtherValue
+        )
+        XCTAssertTrue(
+            Expression.functionCall(
+                call: .custom(function: CustomFunctionCall(name: VariableName(text: "a"), arguments: []))
+            ).isValidOtherValue
+        )
+        XCTAssertFalse(Expression.logical(operation: .and(lhs: a, rhs: b)).isValidOtherValue)
+        XCTAssertTrue(Expression.literal(value: .bit(value: .low)).isValidOtherValue)
+        XCTAssertTrue(Expression.literal(value: .logic(value: .high)).isValidOtherValue)
+        XCTAssertFalse(Expression.literal(value: .boolean(value: false)).isValidOtherValue)
+        XCTAssertTrue(Expression.precedence(value: a).isValidOtherValue)
+        XCTAssertTrue(
+            Expression.reference(variable: .variable(name: VariableName(text: "a"))).isValidOtherValue
+        )
+        XCTAssertFalse(Expression.reference(variable: .indexed(
+            name: VariableName(text: "a"), index: .range(value: .downto(upper: a, lower: b))
+        )).isValidOtherValue)
+        XCTAssertTrue(Expression.reference(variable: .indexed(
+            name: VariableName(text: "a"), index: .index(value: a)
+        )).isValidOtherValue)
+    }
+
 }
 
 // swiftlint:enable type_body_length

--- a/Tests/VHDLParsingTests/IndexedValueTests.swift
+++ b/Tests/VHDLParsingTests/IndexedValueTests.swift
@@ -69,6 +69,13 @@ final class IndexedValueTests: XCTestCase {
         XCTAssertEqual(value.value, .literal(value: .bit(value: .high)))
     }
 
+    /// Test the expression initialiser.
+    func testExpressionInit() {
+        let value = IndexedValue(index: .others, value: .literal(value: .bit(value: .high)))
+        XCTAssertEqual(value.index, .others)
+        XCTAssertEqual(value.value, .literal(value: .bit(value: .high)))
+    }
+
     /// Test `rawValue` creates `VHDL` code correctly.
     func testRawValue() {
         XCTAssertEqual(value.rawValue, "others => '1'")

--- a/Tests/VHDLParsingTests/IndexedValueTests.swift
+++ b/Tests/VHDLParsingTests/IndexedValueTests.swift
@@ -66,7 +66,7 @@ final class IndexedValueTests: XCTestCase {
     /// Test initialiser sets stored properties correctly.
     func testInit() {
         XCTAssertEqual(value.index, .others)
-        XCTAssertEqual(value.value, .bit(value: .high))
+        XCTAssertEqual(value.value, .literal(value: .bit(value: .high)))
     }
 
     /// Test `rawValue` creates `VHDL` code correctly.

--- a/Tests/VHDLParsingTests/IndexedVectorTests.swift
+++ b/Tests/VHDLParsingTests/IndexedVectorTests.swift
@@ -130,4 +130,24 @@ final class IndexedVectorTests: XCTestCase {
         XCTAssertNil(IndexedVector(rawValue: "\n"))
     }
 
+    /// Test `init(rawValue:)` works for mixed types indexes.
+    func testRawValueForMixedIndexes() {
+        let raw = "(0 => a, 1 to 2 => \"UZ\", others => '0')"
+        let expected = IndexedVector(values: [
+            IndexedValue(
+                index: .index(value: .literal(value: .integer(value: 0))),
+                value: .reference(variable: .variable(name: VariableName(text: "a")))
+            ),
+            IndexedValue(
+                index: .range(value: .to(
+                    lower: .literal(value: .integer(value: 1)), upper: .literal(value: .integer(value: 2))
+                )),
+                value: .vector(value: .logics(value: LogicVector(values: [.uninitialized, .highImpedance])))
+            ),
+            IndexedValue(index: .others, value: .bit(value: .low))
+        ])
+        let result = IndexedVector(rawValue: raw)
+        XCTAssertEqual(result, expected)
+    }
+
 }


### PR DESCRIPTION
This PR adds support for more complex values to be assigned in indexed literals. This allows for all expressions to be assigned to an index within a ranged type, e.g. arrays, vectors, records.

This PR also adds 2 helper computed properties to `BinaryOperation` for accessing the left-hand side and right-hand side operands.