### PR TITLE
Detect member access in record types.

### DIFF
--- a/Sources/VHDLParsing/DirectReference.swift
+++ b/Sources/VHDLParsing/DirectReference.swift
@@ -54,13 +54,22 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
+/// A direct reference is a reference to a variable via it's name or member access in a record type.
+/// This enum acts us an umbrella for both of these cases and the underlying parsing is delegated to the
+/// `VariableName` and `MemberAccess` types.
+/// - SeeAlso: ``VariableName``, ``MemberAccess``.
 public indirect enum DirectReference: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 
+    /// A reference to a variable.
     case variable(name: VariableName)
 
+    /// A reference to a member of a record instance.
     case member(access: MemberAccess)
 
-    public var rawValue: String {
+    /// The `VHDL` code representation of this direct reference.
+    @inlinable public var rawValue: String {
         switch self {
         case .variable(let name):
             return name.rawValue
@@ -69,6 +78,9 @@ public indirect enum DirectReference: RawRepresentable, Equatable, Hashable, Cod
         }
     }
 
+    /// Creates a new direct reference from the given `VHDL` code representation.
+    /// - Parameter rawValue: The `VHDL` code representation of this direct reference.
+    @inlinable
     public init?(rawValue: String) {
         let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmedString.count < 2048 else {

--- a/Sources/VHDLParsing/MemberAccess.swift
+++ b/Sources/VHDLParsing/MemberAccess.swift
@@ -83,15 +83,27 @@ public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Send
         let lhs = String(trimmedString[trimmedString.startIndex..<dotIndex])
         let rhs = String(trimmedString[trimmedString.index(after: dotIndex)..<trimmedString.endIndex])
         guard
+            lhs.trimmingCharacters(in: .whitespacesAndNewlines).count == lhs.count,
+            rhs.trimmingCharacters(in: .whitespacesAndNewlines).count == rhs.count,
             let lhsExp = Expression(rawValue: lhs),
             let rhsExp = Expression(rawValue: rhs)
         else {
             return nil
         }
-        guard case .reference = lhsExp else {
+        self.init(lhsExp: lhsExp, rhsExp: rhsExp)
+    }
+
+    init?(lhsExp: Expression, rhsExp: Expression) {
+        if case .reference = lhsExp {
+            if case .reference = rhsExp {
+                self.init(record: lhsExp, member: rhsExp)
+                return
+            } else {
+                return nil
+            }
+        } else {
             return nil
         }
-        self.init(record: lhsExp, member: rhsExp)
     }
 
 }

--- a/Sources/VHDLParsing/MemberAccess.swift
+++ b/Sources/VHDLParsing/MemberAccess.swift
@@ -1,0 +1,91 @@
+// MemberAccess.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Sendable {
+
+    public let record: Expression
+
+    public let member: Expression
+
+    public var rawValue: String {
+        "\(self.record).\(self.member)"
+    }
+
+    public init(record: Expression, member: Expression) {
+        self.record = record
+        self.member = member
+    }
+
+    public init?(rawValue: String) {
+        let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            trimmedString.count >= 3,
+            trimmedString.count < 2048,
+            let dotIndex = trimmedString.firstIndex(of: "."),
+            dotIndex > trimmedString.startIndex,
+            dotIndex < trimmedString.index(before: trimmedString.endIndex)
+        else {
+            return nil
+        }
+        let lhs = String(trimmedString[trimmedString.startIndex..<dotIndex])
+        let rhs = String(trimmedString[trimmedString.index(after: dotIndex)..<trimmedString.endIndex])
+        guard let lhsExp = Expression(rawValue: lhs), let rhsExp = Expression(rawValue: rhs) else {
+            return nil
+        }
+        self.init(record: lhsExp, member: rhsExp)
+    }
+
+}

--- a/Sources/VHDLParsing/MemberAccess.swift
+++ b/Sources/VHDLParsing/MemberAccess.swift
@@ -56,15 +56,15 @@
 
 public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Sendable {
 
-    public let record: Expression
+    public let record: DirectReference
 
-    public let member: Expression
+    public let member: DirectReference
 
     public var rawValue: String {
         "\(self.record.rawValue).\(self.member.rawValue)"
     }
 
-    public init(record: Expression, member: Expression) {
+    public init(record: DirectReference, member: DirectReference) {
         self.record = record
         self.member = member
     }
@@ -85,25 +85,12 @@ public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Send
         guard
             lhs.trimmingCharacters(in: .whitespacesAndNewlines).count == lhs.count,
             rhs.trimmingCharacters(in: .whitespacesAndNewlines).count == rhs.count,
-            let lhsExp = Expression(rawValue: lhs),
-            let rhsExp = Expression(rawValue: rhs)
+            let lhsExp = DirectReference(rawValue: lhs),
+            let rhsExp = DirectReference(rawValue: rhs)
         else {
             return nil
         }
-        self.init(lhsExp: lhsExp, rhsExp: rhsExp)
-    }
-
-    init?(lhsExp: Expression, rhsExp: Expression) {
-        if case .reference = lhsExp {
-            if case .reference = rhsExp {
-                self.init(record: lhsExp, member: rhsExp)
-                return
-            } else {
-                return nil
-            }
-        } else {
-            return nil
-        }
+        self.init(record: lhsExp, member: rhsExp)
     }
 
 }

--- a/Sources/VHDLParsing/MemberAccess.swift
+++ b/Sources/VHDLParsing/MemberAccess.swift
@@ -54,21 +54,46 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
+
+/// An expression accessing a member within a record instance. This type correctly parses the `VHDL` that
+/// is used to access a member within a record. For example, consider the record `foo` with the member `bar`.
+/// The `VHDL` code to access this member would be `foo.bar`. This type correctly parses this code and stores
+/// the record and member as separate properties of this struct. If this `VHDL` is parsed by this type, i.e.
+/// by using `MemberAccess(rawValue: \"foo.bar\")`, then the `record` property will be `foo` and the `member
+/// property will be `bar`.
+/// 
+/// This type also supports chaining member access as the member property is a
+/// ``DirectReference``. For example, consider the record `foo` with the member `bar` which is a record with
+/// the member `baz`. The `VHDL` code to access this member would be `foo.bar.baz`. This type will store
+/// `foo` in the `record` property and `bar.baz` in the `member` property as a ``DirectReference`` instance.
+/// - SeeAlso: ``DirectReference``, ``VariableName``.
 public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Sendable {
 
+    /// The name of the record the `member` belongs too.
     public let record: VariableName
 
+    /// The member that is accessed within the `record`.
     public let member: DirectReference
 
-    public var rawValue: String {
+    /// The `VHDL` code that represents this member access.
+    @inlinable public var rawValue: String {
         "\(self.record.rawValue).\(self.member.rawValue)"
     }
 
+    /// Creates a new instance of this type with the given record and member.
+    /// - Parameters:
+    ///   - record: The name of the record the `member` belongs too.
+    ///   - member: The member that is accessed within the `record`.
+    @inlinable
     public init(record: VariableName, member: DirectReference) {
         self.record = record
         self.member = member
     }
 
+    /// Creates a new instance of this type by parsing the given `VHDL` code.
+    /// - Parameter rawValue: The `VHDL` code to parse.
+    @inlinable
     public init?(rawValue: String) {
         let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard

--- a/Sources/VHDLParsing/MemberAccess.swift
+++ b/Sources/VHDLParsing/MemberAccess.swift
@@ -56,7 +56,7 @@
 
 public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Sendable {
 
-    public let record: DirectReference
+    public let record: VariableName
 
     public let member: DirectReference
 
@@ -64,7 +64,7 @@ public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Send
         "\(self.record.rawValue).\(self.member.rawValue)"
     }
 
-    public init(record: DirectReference, member: DirectReference) {
+    public init(record: VariableName, member: DirectReference) {
         self.record = record
         self.member = member
     }
@@ -85,7 +85,7 @@ public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Send
         guard
             lhs.trimmingCharacters(in: .whitespacesAndNewlines).count == lhs.count,
             rhs.trimmingCharacters(in: .whitespacesAndNewlines).count == rhs.count,
-            let lhsExp = DirectReference(rawValue: lhs),
+            let lhsExp = VariableName(rawValue: lhs),
             let rhsExp = DirectReference(rawValue: rhs)
         else {
             return nil

--- a/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
+++ b/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
@@ -48,6 +48,7 @@
 - ``IndexedValue``
 - ``IndexedVector``
 - ``MathRealFunctionCalls``
+- ``MemberAccess``
 - ``Statement``
 - ``VariableAssignment``
 - ``VariableMap``

--- a/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
+++ b/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
@@ -41,6 +41,7 @@
 - ``ComparisonOperation``
 - ``ConditionalExpression``
 - ``CustomFunctionCall``
+- ``DirectReference``
 - ``EdgeCondition``
 - ``Expression``
 - ``FunctionCall``

--- a/Sources/VHDLParsing/VariableReference.swift
+++ b/Sources/VHDLParsing/VariableReference.swift
@@ -61,7 +61,7 @@ import StringHelpers
 public enum VariableReference: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 
     /// Referencing a variable directly.
-    case variable(name: VariableName)
+    case variable(reference: DirectReference)
 
     /// Indexing a variable.
     case indexed(name: VariableName, index: VectorIndex)
@@ -84,8 +84,8 @@ public enum VariableReference: RawRepresentable, Equatable, Hashable, Codable, S
         guard trimmedString.count < 256 else {
             return nil
         }
-        if let name = VariableName(rawValue: trimmedString) {
-            self = .variable(name: name)
+        if let reference = DirectReference(rawValue: trimmedString) {
+            self = .variable(reference: reference)
             return
         }
         guard let bracketIndex = trimmedString.firstIndex(of: "(") else {

--- a/Tests/VHDLParsingTests/ArchitectureTests.swift
+++ b/Tests/VHDLParsingTests/ArchitectureTests.swift
@@ -71,10 +71,12 @@ final class ArchitectureTests: XCTestCase {
         sensitivityList: [VariableName(text: "clk")],
         code: .ifStatement(block: .ifStatement(
             condition: .conditional(condition: .edge(
-                value: .rising(expression: .reference(variable: .variable(name: VariableName(text: "clk"))))
+                value: .rising(expression: .reference(
+                    variable: .variable(reference: .variable(name: VariableName(text: "clk")))
+                ))
             )),
             ifBlock: .statement(statement: .assignment(
-                name: .variable(name: VariableName(text: "x")),
+                name: .variable(reference: .variable(name: VariableName(text: "x"))),
                 value: .literal(value: .bit(value: .high))
             ))
         ))

--- a/Tests/VHDLParsingTests/AsynchronousBlockTests.swift
+++ b/Tests/VHDLParsingTests/AsynchronousBlockTests.swift
@@ -70,25 +70,25 @@ final class AsynchronousBlockTests: XCTestCase {
     let clk = VariableName(text: "clk")
 
     /// An expression for `x`.
-    lazy var varX = Expression.reference(variable: .variable(name: x))
+    lazy var varX = Expression.reference(variable: .variable(reference: .variable(name: x)))
 
     /// An expression for `y`.
-    lazy var varY = Expression.reference(variable: .variable(name: y))
+    lazy var varY = Expression.reference(variable: .variable(reference: .variable(name: y)))
 
     /// An expression for `clk`.
-    lazy var varClk = Expression.reference(variable: .variable(name: clk))
+    lazy var varClk = Expression.reference(variable: .variable(reference: .variable(name: clk)))
 
     /// Reset test data.
     override func setUp() {
         super.setUp()
-        varX = Expression.reference(variable: .variable(name: x))
-        varY = Expression.reference(variable: .variable(name: y))
-        varClk = Expression.reference(variable: .variable(name: clk))
+        varX = Expression.reference(variable: .variable(reference: .variable(name: x)))
+        varY = Expression.reference(variable: .variable(reference: .variable(name: y)))
+        varClk = Expression.reference(variable: .variable(reference: .variable(name: clk)))
     }
 
     /// Test `rawValue` is correct.
     func testRawValue() {
-        let statement = Statement.assignment(name: .variable(name: x), value: varY)
+        let statement = Statement.assignment(name: .variable(reference: .variable(name: x)), value: varY)
         let block = AsynchronousBlock.statement(statement: statement)
         let blockRaw = "x <= y;"
         XCTAssertEqual(block.rawValue, blockRaw)
@@ -119,7 +119,7 @@ final class AsynchronousBlockTests: XCTestCase {
 
     /// Test raw value init for process.
     func testProcessRawValueInit() {
-        let statement = Statement.assignment(name: .variable(name: x), value: varY)
+        let statement = Statement.assignment(name: .variable(reference: .variable(name: x)), value: varY)
         let raw = """
         process (clk)
         begin
@@ -155,7 +155,7 @@ final class AsynchronousBlockTests: XCTestCase {
 
     /// Test raw value init for statement.
     func testStatementRawValueInit() {
-        let statement = Statement.assignment(name: .variable(name: x), value: varY)
+        let statement = Statement.assignment(name: .variable(reference: .variable(name: x)), value: varY)
         let block = AsynchronousBlock.statement(statement: statement)
         let raw = "x <= y;"
         XCTAssertEqual(AsynchronousBlock(rawValue: raw), block)
@@ -165,7 +165,7 @@ final class AsynchronousBlockTests: XCTestCase {
 
     /// test raw value init for multiple statements.
     func testMultipleStatementsRawValueInit() {
-        let statement = Statement.assignment(name: .variable(name: x), value: varY)
+        let statement = Statement.assignment(name: .variable(reference: .variable(name: x)), value: varY)
         let block = AsynchronousBlock.statement(statement: statement)
         let raw = """
         x <= y;
@@ -177,7 +177,7 @@ final class AsynchronousBlockTests: XCTestCase {
 
     /// Test init works for multiple statements.
     func testMultipleRawValueInit() {
-        let statement = Statement.assignment(name: .variable(name: x), value: varY)
+        let statement = Statement.assignment(name: .variable(reference: .variable(name: x)), value: varY)
         let block = AsynchronousBlock.statement(statement: statement)
         let process = AsynchronousBlock.process(
             block: ProcessBlock(
@@ -194,8 +194,11 @@ final class AsynchronousBlockTests: XCTestCase {
             label: VariableName(text: "comp1"),
             name: VariableName(text: "C1"),
             port: PortMap(variables: [
-                VariableMap(lhs: .variable(name: x), rhs: .reference(variable: .variable(name: y))),
-                VariableMap(lhs: .variable(name: VariableName(text: "z")), rhs: .open)
+                VariableMap(
+                    lhs: .variable(reference: .variable(name: x)),
+                    rhs: .reference(variable: .variable(reference: .variable(name: y)))
+                ),
+                VariableMap(lhs: .variable(reference: .variable(name: VariableName(text: "z"))), rhs: .open)
             ])
         ))
         let raw = """
@@ -224,8 +227,11 @@ final class AsynchronousBlockTests: XCTestCase {
             label: VariableName(text: "comp1"),
             name: VariableName(text: "C1"),
             port: PortMap(variables: [
-                VariableMap(lhs: .variable(name: x), rhs: .reference(variable: .variable(name: y))),
-                VariableMap(lhs: .variable(name: VariableName(text: "z")), rhs: .open)
+                VariableMap(
+                    lhs: .variable(reference: .variable(name: x)),
+                    rhs: .reference(variable: .variable(reference: .variable(name: y)))
+                ),
+                VariableMap(lhs: .variable(reference: .variable(name: VariableName(text: "z"))), rhs: .open)
             ])
         ))
         let raw = """

--- a/Tests/VHDLParsingTests/BinaryOperationTests.swift
+++ b/Tests/VHDLParsingTests/BinaryOperationTests.swift
@@ -61,10 +61,10 @@ import XCTest
 final class BinaryOperationTests: XCTestCase {
 
     /// A variable called `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// The variable y.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// Test raw values are correct.
     func testRawValues() {
@@ -89,7 +89,7 @@ final class BinaryOperationTests: XCTestCase {
             BinaryOperation(rawValue: "x + y + z "),
             BinaryOperation.addition(
                 lhs: .binary(operation: .addition(lhs: x, rhs: y)),
-                rhs: .reference(variable: .variable(name: VariableName(text: "z")))
+                rhs: .reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
             )
         )
     }
@@ -109,7 +109,7 @@ final class BinaryOperationTests: XCTestCase {
             BinaryOperation(rawValue: "x - y - z "),
             BinaryOperation.subtraction(
                 lhs: .binary(operation: .subtraction(lhs: x, rhs: y)),
-                rhs: .reference(variable: .variable(name: VariableName(text: "z")))
+                rhs: .reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
             )
         )
     }
@@ -129,7 +129,7 @@ final class BinaryOperationTests: XCTestCase {
             BinaryOperation(rawValue: "x * y * z "),
             BinaryOperation.multiplication(
                 lhs: .binary(operation: .multiplication(lhs: x, rhs: y)),
-                rhs: .reference(variable: .variable(name: VariableName(text: "z")))
+                rhs: .reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
             )
         )
     }
@@ -149,7 +149,7 @@ final class BinaryOperationTests: XCTestCase {
             BinaryOperation(rawValue: "x / y / z "),
             BinaryOperation.division(
                 lhs: .binary(operation: .division(lhs: x, rhs: y)),
-                rhs: .reference(variable: .variable(name: VariableName(text: "z")))
+                rhs: .reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
             )
         )
     }

--- a/Tests/VHDLParsingTests/BooleanExpressionTests.swift
+++ b/Tests/VHDLParsingTests/BooleanExpressionTests.swift
@@ -61,13 +61,13 @@ import XCTest
 final class BooleanExpressionTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// A variable `y`.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// A variable `z`.
-    let z = Expression.reference(variable: .variable(name: VariableName(text: "z")))
+    let z = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
 
     /// Test the raw values generate the correct `VHDL` code.
     func testRawValue() {
@@ -327,11 +327,15 @@ final class BooleanExpressionTests: XCTestCase {
                     lhs: .precedence(value: .logical(operation: .not(
                         value: .precedence(value: .logical(operation: .and(
                             lhs: .conditional(condition: .comparison(value: .equality(
-                                lhs: .reference(variable: .variable(name: VariableName(text: "statusIn"))),
+                                lhs: .reference(variable: .variable(
+                                    reference: .variable(name: VariableName(text: "statusIn"))
+                                )),
                                 rhs: .literal(value: .bit(value: .high))
                             ))),
                             rhs: .conditional(condition: .comparison(value: .equality(
-                                lhs: .reference(variable: .variable(name: VariableName(text: "count"))),
+                                lhs: .reference(variable: .variable(
+                                    reference: .variable(name: VariableName(text: "count"))
+                                )),
                                 rhs: .literal(
                                     value: .vector(value: .bits(
                                         value: BitVector(values: [.low, .low, .high, .low])
@@ -342,7 +346,9 @@ final class BooleanExpressionTests: XCTestCase {
                     ))),
                     rhs: .precedence(value: .logical(operation: .not(
                         value: .precedence(value: .conditional(condition: .comparison(value: .equality(
-                            lhs: .reference(variable: .variable(name: VariableName(text: "count"))),
+                            lhs: .reference(
+                                variable: .variable(reference: .variable(name: VariableName(text: "count")))
+                            ),
                             rhs: .literal(value: .vector(
                                 value: .bits(value: BitVector(values: [.low, .low, .high, .high]))
                             ))

--- a/Tests/VHDLParsingTests/CaseStatementTests.swift
+++ b/Tests/VHDLParsingTests/CaseStatementTests.swift
@@ -61,14 +61,17 @@ import XCTest
 final class CaseStatementTests: XCTestCase {
 
     /// The condition of the case statement.
-    let condition = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let condition = Expression.reference(variable: .variable(
+        reference: .variable(name: VariableName(text: "x"))
+    ))
 
     /// The cases of the statement.
     let cases = [
         WhenCase(
             condition: .expression(expression: .literal(value: .bit(value: .high))),
             code: .statement(statement: .assignment(
-                name: .variable(name: VariableName(text: "y")), value: .literal(value: .bit(value: .low))
+                name: .variable(reference: .variable(name: VariableName(text: "y"))),
+                value: .literal(value: .bit(value: .low))
             ))
         ),
         WhenCase.othersNull

--- a/Tests/VHDLParsingTests/CastOperationTests.swift
+++ b/Tests/VHDLParsingTests/CastOperationTests.swift
@@ -61,7 +61,7 @@ import XCTest
 final class CastOperationTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// Test the raw values generate the correct `VHDL` code.
     func testRawValue() {

--- a/Tests/VHDLParsingTests/ComparisonOperationTests.swift
+++ b/Tests/VHDLParsingTests/ComparisonOperationTests.swift
@@ -61,10 +61,10 @@ import XCTest
 final class ComparisonOperationTests: XCTestCase {
 
     /// The variable x.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// The variable y.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// Test that the `rawValue` property creates the correct `VHDL` code.
     func testRawValue() {

--- a/Tests/VHDLParsingTests/ComponentInstantiationTests.swift
+++ b/Tests/VHDLParsingTests/ComponentInstantiationTests.swift
@@ -69,17 +69,17 @@ final class ComponentInstantiationTests: XCTestCase {
     /// The port map.
     let port = PortMap(variables: [
         VariableMap(
-            lhs: .variable(name: VariableName(text: "x")),
-            rhs: .reference(variable: .variable(name: VariableName(text: "z")))
+            lhs: .variable(reference: .variable(name: VariableName(text: "x"))),
+            rhs: .reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
         ),
-        VariableMap(lhs: .variable(name: VariableName(text: "y")), rhs: .open)
+        VariableMap(lhs: .variable(reference: .variable(name: VariableName(text: "y"))), rhs: .open)
     ])
 
     /// The generic map.
     let generic = GenericMap(variables: [
         GenericVariableMap(
-            lhs: .variable(name: VariableName(text: "N")),
-            rhs: .reference(variable: .variable(name: VariableName(text: "A")))
+            lhs: .variable(reference: .variable(name: VariableName(text: "N"))),
+            rhs: .reference(variable: .variable(reference: .variable(name: VariableName(text: "A"))))
         )
     ])
 

--- a/Tests/VHDLParsingTests/ConditionalExpressionTests.swift
+++ b/Tests/VHDLParsingTests/ConditionalExpressionTests.swift
@@ -61,10 +61,10 @@ import XCTest
 final class ConditionalExpressionTests: XCTestCase {
 
     /// A variable called `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// The variable y.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// Test `rawValue` delegates to operations `rawValue`.
     func testRawValue() {

--- a/Tests/VHDLParsingTests/CustomFunctionCallTests.swift
+++ b/Tests/VHDLParsingTests/CustomFunctionCallTests.swift
@@ -64,10 +64,10 @@ final class CustomFunctionCallTests: XCTestCase {
     let f = VariableName(text: "f")
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// A variable `y`.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// The function arguments.
     var arguments: [Expression] {

--- a/Tests/VHDLParsingTests/DirectReferenceTests.swift
+++ b/Tests/VHDLParsingTests/DirectReferenceTests.swift
@@ -1,0 +1,109 @@
+// DirectReferenceTests.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLParsing
+import XCTest
+
+/// Test class for ``DirectReference``.
+final class DirectReferenceTests: XCTestCase {
+
+    /// The name of a record.
+    let record = VariableName(text: "recordA")
+
+    /// The name of a member inside `record`.
+    let member = VariableName(text: "member")
+
+    /// A reference to `record`.
+    var varRef: DirectReference {
+        .variable(name: record)
+    }
+
+    /// A reference to `member` inside `record`.
+    var memberRef: DirectReference {
+        .member(access: MemberAccess(record: record, member: .variable(name: member)))
+    }
+
+    /// A reference to a chained member inside a record.
+    var chainedAccess: DirectReference {
+        .member(
+            access: MemberAccess(
+                record: record,
+                member: .member(access: MemberAccess(
+                    record: VariableName(text: "recordB"), member: .variable(name: member)
+                ))
+            )
+        )
+    }
+
+    /// Test the `rawValue` produces the correct `VHDL` code.
+    func testRawValue() {
+        XCTAssertEqual(varRef.rawValue, "recordA")
+        XCTAssertEqual(memberRef.rawValue, "recordA.member")
+        XCTAssertEqual(chainedAccess.rawValue, "recordA.recordB.member")
+    }
+
+    /// Test that the `VHDL` code is parsed correctly in `init(rawValue:)`.
+    func testRawValueInit() {
+        XCTAssertEqual(DirectReference(rawValue: "recordA"), varRef)
+        XCTAssertEqual(DirectReference(rawValue: "recordA.member"), memberRef)
+        XCTAssertEqual(DirectReference(rawValue: "recordA.recordB.member"), chainedAccess)
+        XCTAssertNil(DirectReference(rawValue: "\(String(repeating: "A", count: 2048))"))
+        XCTAssertNil(DirectReference(rawValue: ""))
+        XCTAssertNil(DirectReference(rawValue: " "))
+        XCTAssertNil(DirectReference(rawValue: "record"))
+    }
+
+}

--- a/Tests/VHDLParsingTests/EdgeConditionTests.swift
+++ b/Tests/VHDLParsingTests/EdgeConditionTests.swift
@@ -61,7 +61,7 @@ import XCTest
 final class EdgeConditionTests: XCTestCase {
 
     /// A variable called `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// Test expression property gets the correct expression.
     func testExpression() {

--- a/Tests/VHDLParsingTests/ExpressionTests.swift
+++ b/Tests/VHDLParsingTests/ExpressionTests.swift
@@ -78,19 +78,19 @@ final class ExpressionTests: XCTestCase {
     let ename = VariableName(text: "e")
 
     /// Expression `a`.
-    var a: Expression { .reference(variable: .variable(name: aname)) }
+    var a: Expression { .reference(variable: .variable(reference: .variable(name: aname))) }
 
     /// Expression `b`.
-    var b: Expression { .reference(variable: .variable(name: bname)) }
+    var b: Expression { .reference(variable: .variable(reference: .variable(name: bname))) }
 
     /// Expression `c`.
-    var c: Expression { .reference(variable: .variable(name: cname)) }
+    var c: Expression { .reference(variable: .variable(reference: .variable(name: cname))) }
 
     /// Expression `d`.
-    var d: Expression { .reference(variable: .variable(name: dname)) }
+    var d: Expression { .reference(variable: .variable(reference: .variable(name: dname))) }
 
     /// Expression `e`.
-    var e: Expression { .reference(variable: .variable(name: ename)) }
+    var e: Expression { .reference(variable: .variable(reference: .variable(name: ename))) }
 
     /// Test raw values are correct.
     func testRawValues() {
@@ -434,7 +434,9 @@ final class ExpressionTests: XCTestCase {
         XCTAssertFalse(Expression.literal(value: .boolean(value: false)).isValidOtherValue)
         XCTAssertTrue(Expression.precedence(value: a).isValidOtherValue)
         XCTAssertTrue(
-            Expression.reference(variable: .variable(name: VariableName(text: "a"))).isValidOtherValue
+            Expression.reference(
+                variable: .variable(reference: .variable(name: VariableName(text: "a")))
+            ).isValidOtherValue
         )
         XCTAssertFalse(Expression.reference(variable: .indexed(
             name: VariableName(text: "a"), index: .range(value: .downto(upper: a, lower: b))

--- a/Tests/VHDLParsingTests/ForLoopTests.swift
+++ b/Tests/VHDLParsingTests/ForLoopTests.swift
@@ -73,7 +73,10 @@ final class ForLoopTests: XCTestCase {
 
     /// The block of the for-loop.
     lazy var code = SynchronousBlock.statement(
-        statement: .assignment(name: .variable(name: y), value: .reference(variable: .variable(name: x)))
+        statement: .assignment(
+            name: .variable(reference: .variable(name: y)),
+            value: .reference(variable: .variable(reference: .variable(name: x)))
+        )
     )
 
     /// The loop under test.
@@ -82,7 +85,10 @@ final class ForLoopTests: XCTestCase {
     /// Initialise the test data.
     override func setUp() {
         code = SynchronousBlock.statement(
-            statement: .assignment(name: .variable(name: y), value: .reference(variable: .variable(name: x)))
+            statement: .assignment(
+                name: .variable(reference: .variable(name: y)),
+                value: .reference(variable: .variable(reference: .variable(name: x)))
+            )
         )
         loop = ForLoop(iterator: x, range: range, body: code)
     }

--- a/Tests/VHDLParsingTests/FunctionCallTests.swift
+++ b/Tests/VHDLParsingTests/FunctionCallTests.swift
@@ -61,7 +61,7 @@ import XCTest
 final class FunctionCallTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// Test that `rawValue` generates the correct `VHDL` code.
     func testRawValue() {

--- a/Tests/VHDLParsingTests/GenericMapTests.swift
+++ b/Tests/VHDLParsingTests/GenericMapTests.swift
@@ -61,13 +61,13 @@ import XCTest
 final class GenericMapTests: XCTestCase {
 
     /// A variable `x`.
-    let x = VariableReference.variable(name: VariableName(text: "x"))
+    let x = VariableReference.variable(reference: .variable(name: VariableName(text: "x")))
 
     /// A variable `y`.
-    let y = VariableReference.variable(name: VariableName(text: "y"))
+    let y = VariableReference.variable(reference: .variable(name: VariableName(text: "y")))
 
     /// A variable `z`.
-    let z = Expression.reference(variable: .variable(name: VariableName(text: "z")))
+    let z = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "z"))))
 
     /// The `GenericMap` under test.
     lazy var map = GenericMap(

--- a/Tests/VHDLParsingTests/GenericVariableMapTests.swift
+++ b/Tests/VHDLParsingTests/GenericVariableMapTests.swift
@@ -61,10 +61,10 @@ import XCTest
 final class GenericVariableMapTests: XCTestCase {
 
     /// A variable `x`.
-    let x = VariableReference.variable(name: VariableName(text: "x"))
+    let x = VariableReference.variable(reference: .variable(name: VariableName(text: "x")))
 
     /// A variable `y`.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// The map under test.
     lazy var map = GenericVariableMap(lhs: x, rhs: y)

--- a/Tests/VHDLParsingTests/IfBlockTests.swift
+++ b/Tests/VHDLParsingTests/IfBlockTests.swift
@@ -63,19 +63,22 @@ import XCTest
 final class IfBlockTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// A variable `y`.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// Test `rawValue` generates `VHDL` code correctly.
     func testRawValue() {
         let condition = Expression.conditional(condition: .comparison(value: .equality(lhs: x, rhs: y)))
         let assignment = SynchronousBlock.statement(
-            statement: Statement.assignment(name: .variable(name: VariableName(text: "x")), value: y)
+            statement: Statement.assignment(
+                name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+            )
         )
         let reset = SynchronousBlock.statement(statement: Statement.assignment(
-            name: .variable(name: VariableName(text: "x")), value: .literal(value: .bit(value: .low))
+            name: .variable(reference: .variable(name: VariableName(text: "x"))),
+            value: .literal(value: .bit(value: .low))
         ))
         let block = IfBlock.ifStatement(condition: condition, ifBlock: assignment)
         let expected = """
@@ -100,13 +103,17 @@ final class IfBlockTests: XCTestCase {
         let block = IfBlock.ifElse(
             condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
             ifBlock: .statement(
-                statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                statement: .assignment(
+                    name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                )
             ),
             elseBlock: .ifStatement(
                 block: .ifStatement(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "y")), value: x)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                        )
                     )
                 )
             )
@@ -126,17 +133,21 @@ final class IfBlockTests: XCTestCase {
         let block = IfBlock.ifElse(
             condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
             ifBlock: .statement(
-                statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                statement: .assignment(
+                    name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                )
             ),
             elseBlock: .ifStatement(
                 block: .ifElse(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "y")), value: x)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                        )
                     ),
                     elseBlock: .statement(
                         statement: .assignment(
-                            name: .variable(name: VariableName(text: "x")),
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))),
                             value: .literal(value: .bit(value: .low))
                         )
                     )
@@ -162,13 +173,17 @@ final class IfBlockTests: XCTestCase {
         let block = IfBlock.ifElse(
             condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
             ifBlock: .statement(
-                statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                statement: .assignment(
+                    name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                )
             ),
             elseBlock: .ifStatement(
                 block: .ifElse(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "y")), value: x)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                        )
                     ),
                     elseBlock: .ifStatement(
                         block: .ifElse(
@@ -177,7 +192,7 @@ final class IfBlockTests: XCTestCase {
                             ),
                             ifBlock: .statement(
                                 statement: .assignment(
-                                    name: .variable(name: VariableName(text: "x")),
+                                    name: .variable(reference: .variable(name: VariableName(text: "x"))),
                                     value: .binary(
                                         operation: .addition(lhs: x, rhs: .literal(value: .integer(value: 1)))
                                     )
@@ -190,7 +205,9 @@ final class IfBlockTests: XCTestCase {
                                     ),
                                     ifBlock: .statement(
                                         statement: .assignment(
-                                            name: .variable(name: VariableName(text: "x")),
+                                            name: .variable(reference: .variable(
+                                                name: VariableName(text: "x")
+                                            )),
                                             value: .binary(
                                                 operation: .subtraction(
                                                     lhs: x, rhs: .literal(value: .integer(value: 1))
@@ -200,7 +217,9 @@ final class IfBlockTests: XCTestCase {
                                     ),
                                     elseBlock: .statement(
                                         statement: .assignment(
-                                            name: .variable(name: VariableName(text: "x")),
+                                            name: .variable(reference: .variable(
+                                                name: VariableName(text: "x")
+                                            )),
                                             value: .literal(value: .bit(value: .low))
                                         )
                                     )
@@ -234,7 +253,9 @@ final class IfBlockTests: XCTestCase {
             ifBlock: .blocks(
                 blocks: [
                     .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                        )
                     ),
                     .ifStatement(
                         block: IfBlock.ifStatement(
@@ -245,7 +266,7 @@ final class IfBlockTests: XCTestCase {
                             ),
                             ifBlock: .statement(
                                 statement: .assignment(
-                                    name: .variable(name: VariableName(text: "x")),
+                                    name: .variable(reference: .variable(name: VariableName(text: "x"))),
                                     value: .literal(value: .bit(value: .low))
                                 )
                             )
@@ -257,11 +278,13 @@ final class IfBlockTests: XCTestCase {
                 block: .ifElse(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "y")), value: x)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                        )
                     ),
                     elseBlock: .statement(
                         statement: .assignment(
-                            name: .variable(name: VariableName(text: "x")),
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))),
                             value: .literal(value: .bit(value: .low))
                         )
                     )
@@ -299,7 +322,9 @@ final class IfBlockTests: XCTestCase {
                     condition: .comparison(value: .equality(lhs: x, rhs: y))
                 ),
                 ifBlock: SynchronousBlock.statement(
-                    statement: Statement.assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                    statement: Statement.assignment(
+                        name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                    )
                 )
             )
         )
@@ -313,11 +338,13 @@ final class IfBlockTests: XCTestCase {
         let expected = IfBlock.ifElse(
             condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
             ifBlock: .statement(
-                statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                statement: .assignment(
+                    name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                )
             ),
             elseBlock: .statement(
                 statement: .assignment(
-                    name: .variable(name: VariableName(text: "x")),
+                    name: .variable(reference: .variable(name: VariableName(text: "x"))),
                     value: .literal(value: .bit(value: .low))
                 )
             )
@@ -339,17 +366,21 @@ final class IfBlockTests: XCTestCase {
         let expected = IfBlock.ifElse(
             condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
             ifBlock: .statement(
-                statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                statement: .assignment(
+                    name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                )
             ),
             elseBlock: .ifStatement(
                 block: .ifElse(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "y")), value: x)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                        )
                     ),
                     elseBlock: .statement(
                         statement: .assignment(
-                            name: .variable(name: VariableName(text: "x")),
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))),
                             value: .literal(value: .bit(value: .low))
                         )
                     )
@@ -380,7 +411,9 @@ final class IfBlockTests: XCTestCase {
             ifBlock: .blocks(
                 blocks: [
                     .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                        )
                     ),
                     .ifStatement(
                         block: IfBlock.ifStatement(
@@ -391,7 +424,7 @@ final class IfBlockTests: XCTestCase {
                             ),
                             ifBlock: .statement(
                                 statement: .assignment(
-                                    name: .variable(name: VariableName(text: "x")),
+                                    name: .variable(reference: .variable(name: VariableName(text: "x"))),
                                     value: .literal(value: .bit(value: .low))
                                 )
                             )
@@ -403,11 +436,13 @@ final class IfBlockTests: XCTestCase {
                 block: .ifElse(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "y")), value: x)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                        )
                     ),
                     elseBlock: .statement(
                         statement: .assignment(
-                            name: .variable(name: VariableName(text: "x")),
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))),
                             value: .literal(value: .bit(value: .low))
                         )
                     )
@@ -426,7 +461,9 @@ final class IfBlockTests: XCTestCase {
             IfBlock.ifStatement(
                 condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
                 ifBlock: .statement(
-                    statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                    statement: .assignment(
+                        name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                    )
                 )
             )
         )
@@ -435,7 +472,9 @@ final class IfBlockTests: XCTestCase {
             IfBlock.ifStatement(
                 condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
                 ifBlock: .statement(
-                    statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                    statement: .assignment(
+                        name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                    )
                 )
             )
         )

--- a/Tests/VHDLParsingTests/IndexedValueTests.swift
+++ b/Tests/VHDLParsingTests/IndexedValueTests.swift
@@ -126,28 +126,36 @@ final class IndexedValueTests: XCTestCase {
         XCTAssertEqual(
             IndexedValue(rawValue: "x => (others => '0')"),
             IndexedValue(
-                index: .index(value: .reference(variable: .variable(name: VariableName(text: "x")))),
+                index: .index(value: .reference(
+                    variable: .variable(reference: .variable(name: VariableName(text: "x")))
+                )),
                 value: .literal(value: .vector(value: .indexed(values: IndexedVector(
                     values: [IndexedValue(index: .others, value: .bit(value: .low))]
                 ))))
             )
         )
+        XCTAssertEqual(
+            IndexedValue(rawValue: "abx => '1'"),
+            IndexedValue(
+                index: .index(value: .reference(variable: .variable(
+                    reference: .variable(name: VariableName(text: "abx"))
+                ))),
+                value: .bit(value: .high)
+            )
+        )
+    }
+
+    /// Test `init(rawValue:)` correctly detects invalid code.
+    func testRawValueInitFails() {
+        XCTAssertNil(IndexedValue(rawValue: "signal x: std_logic_vector(3 downto 0) := (others => '1');"))
+        XCTAssertNil(IndexedValue(rawValue: "others => \"1\""))
+        XCTAssertNil(IndexedValue(rawValue: "others => 1"))
         XCTAssertNil(IndexedValue(rawValue: "others => '1' => '0'"))
         XCTAssertNil(IndexedValue(rawValue: "2 => '1', others => '0'"))
         XCTAssertNil(IndexedValue(rawValue: ""))
         XCTAssertNil(IndexedValue(rawValue: " "))
         XCTAssertNil(IndexedValue(rawValue: "\n"))
         XCTAssertNil(IndexedValue(rawValue: "\(String(repeating: "1", count: 256)) => '1'"))
-        XCTAssertEqual(
-            IndexedValue(rawValue: "abx => '1'"),
-            IndexedValue(
-                index: .index(value: .reference(variable: .variable(name: VariableName(text: "abx")))),
-                value: .bit(value: .high)
-            )
-        )
-        XCTAssertNil(IndexedValue(rawValue: "signal x: std_logic_vector(3 downto 0) := (others => '1');"))
-        XCTAssertNil(IndexedValue(rawValue: "others => \"1\""))
-        XCTAssertNil(IndexedValue(rawValue: "others => 1"))
     }
 
 }

--- a/Tests/VHDLParsingTests/IndexedVectorTests.swift
+++ b/Tests/VHDLParsingTests/IndexedVectorTests.swift
@@ -139,7 +139,7 @@ final class IndexedVectorTests: XCTestCase {
         let expected = IndexedVector(values: [
             IndexedValue(
                 index: .index(value: .literal(value: .integer(value: 0))),
-                value: .reference(variable: .variable(name: VariableName(text: "a")))
+                value: .reference(variable: .variable(reference: .variable(name: VariableName(text: "a"))))
             ),
             IndexedValue(
                 index: .range(value: .to(

--- a/Tests/VHDLParsingTests/MathRealFunctionCallsTests.swift
+++ b/Tests/VHDLParsingTests/MathRealFunctionCallsTests.swift
@@ -61,10 +61,10 @@ import XCTest
 final class MathRealFunctionCallsTests: XCTestCase {
 
     /// A variable `x`.
-    let x = Expression.reference(variable: .variable(name: VariableName(text: "x")))
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// A variable `y`.
-    let y = Expression.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "y"))))
 
     /// Test `rawValue` generated `VHDL` code correctly.
     func testRawValue() {

--- a/Tests/VHDLParsingTests/MemberAccessTests.swift
+++ b/Tests/VHDLParsingTests/MemberAccessTests.swift
@@ -61,7 +61,7 @@ import XCTest
 final class MemberAccessTests: XCTestCase {
 
     /// The record to access.
-    let record = DirectReference.variable(name: VariableName(text: "recordA"))
+    let record = VariableName(text: "recordA")
 
     /// The member in record to access.
     let member = DirectReference.variable(name: VariableName(text: "member"))
@@ -95,7 +95,7 @@ final class MemberAccessTests: XCTestCase {
             MemberAccess(
                 record: record,
                 member: .member(access: MemberAccess(
-                    record: .variable(name: VariableName(text: "recordB")), member: member
+                    record: VariableName(text: "recordB"), member: member
                 ))
             )
         )

--- a/Tests/VHDLParsingTests/MemberAccessTests.swift
+++ b/Tests/VHDLParsingTests/MemberAccessTests.swift
@@ -1,4 +1,4 @@
-// MemberAccess.swift
+// MemberAccessTests.swift
 // VHDLParsing
 // 
 // Created by Morgan McColl.
@@ -54,44 +54,35 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
-public struct MemberAccess: Codable, Equatable, Hashable, RawRepresentable, Sendable {
+@testable import VHDLParsing
+import XCTest
 
-    public let record: Expression
+/// Test class for ``MemberAccess``.
+final class MemberAccessTests: XCTestCase {
 
-    public let member: Expression
+    /// The record to access.
+    let record = Expression.reference(variable: .variable(name: VariableName(text: "record")))
 
-    public var rawValue: String {
-        "\(self.record.rawValue).\(self.member.rawValue)"
+    /// The member in record to access.
+    let member = Expression.reference(variable: .variable(name: VariableName(text: "member")))
+
+    /// The access unit under test.
+    lazy var memberAccess = MemberAccess(record: record, member: member)
+
+    /// Initialise the uut before each test.
+    override func setUp() {
+        memberAccess = MemberAccess(record: record, member: member)
     }
 
-    public init(record: Expression, member: Expression) {
-        self.record = record
-        self.member = member
+    /// Test `init(record:,member:)` functions correctly.
+    func testPropertyInit() {
+        XCTAssertEqual(memberAccess.record, record)
+        XCTAssertEqual(memberAccess.member, member)
     }
 
-    public init?(rawValue: String) {
-        let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard
-            trimmedString.count >= 3,
-            trimmedString.count < 2048,
-            let dotIndex = trimmedString.firstIndex(of: "."),
-            dotIndex > trimmedString.startIndex,
-            dotIndex < trimmedString.index(before: trimmedString.endIndex)
-        else {
-            return nil
-        }
-        let lhs = String(trimmedString[trimmedString.startIndex..<dotIndex])
-        let rhs = String(trimmedString[trimmedString.index(after: dotIndex)..<trimmedString.endIndex])
-        guard
-            let lhsExp = Expression(rawValue: lhs),
-            let rhsExp = Expression(rawValue: rhs)
-        else {
-            return nil
-        }
-        guard case .reference = lhsExp else {
-            return nil
-        }
-        self.init(record: lhsExp, member: rhsExp)
+    /// Test the `rawValue` generates the correct String.
+    func testRawValue() {
+        XCTAssertEqual(memberAccess.rawValue, "record.member")
     }
 
 }

--- a/Tests/VHDLParsingTests/MemberAccessTests.swift
+++ b/Tests/VHDLParsingTests/MemberAccessTests.swift
@@ -61,7 +61,7 @@ import XCTest
 final class MemberAccessTests: XCTestCase {
 
     /// The record to access.
-    let record = Expression.reference(variable: .variable(name: VariableName(text: "record")))
+    let record = Expression.reference(variable: .variable(name: VariableName(text: "recordA")))
 
     /// The member in record to access.
     let member = Expression.reference(variable: .variable(name: VariableName(text: "member")))
@@ -82,7 +82,22 @@ final class MemberAccessTests: XCTestCase {
 
     /// Test the `rawValue` generates the correct String.
     func testRawValue() {
-        XCTAssertEqual(memberAccess.rawValue, "record.member")
+        XCTAssertEqual(memberAccess.rawValue, "recordA.member")
+    }
+
+    /// Test `init(rawValue:)` correctly parses the string.
+    func testRawValueInit() {
+        let memberAccess = MemberAccess(rawValue: "recordA.member")
+        XCTAssertEqual(self.memberAccess, memberAccess)
+        XCTAssertNil(MemberAccess(rawValue: "recordA .member"))
+        XCTAssertNil(MemberAccess(rawValue: "recordA . member"))
+        XCTAssertNil(MemberAccess(rawValue: "recordA. member"))
+        XCTAssertNil(MemberAccess(rawValue: "."))
+        XCTAssertNil(MemberAccess(rawValue: "recordA."))
+        XCTAssertNil(MemberAccess(rawValue: ".member"))
+        XCTAssertNil(MemberAccess(rawValue: "recordAmember"))
+        XCTAssertNil(MemberAccess(rawValue: "(A + B).member"))
+        XCTAssertNil(MemberAccess(rawValue: "recordA.(A + B)"))
     }
 
 }

--- a/Tests/VHDLParsingTests/MemberAccessTests.swift
+++ b/Tests/VHDLParsingTests/MemberAccessTests.swift
@@ -87,8 +87,10 @@ final class MemberAccessTests: XCTestCase {
 
     /// Test `init(rawValue:)` correctly parses the string.
     func testRawValueInit() {
-        let memberAccess = MemberAccess(rawValue: "recordA.member")
-        XCTAssertEqual(self.memberAccess, memberAccess)
+        XCTAssertEqual(memberAccess, MemberAccess(rawValue: "recordA.member"))
+        XCTAssertEqual(memberAccess, MemberAccess(rawValue: "recordA.member "))
+        XCTAssertEqual(memberAccess, MemberAccess(rawValue: " recordA.member"))
+        XCTAssertEqual(memberAccess, MemberAccess(rawValue: " recordA.member "))
         let chainedAccess = MemberAccess(rawValue: "recordA.recordB.member")
         XCTAssertEqual(
             chainedAccess,
@@ -99,6 +101,7 @@ final class MemberAccessTests: XCTestCase {
                 ))
             )
         )
+        XCTAssertNil(MemberAccess(rawValue: "\(String(repeating: "A", count: 2048)).B"))
         XCTAssertNil(MemberAccess(rawValue: "recordA .member"))
         XCTAssertNil(MemberAccess(rawValue: "recordA . member"))
         XCTAssertNil(MemberAccess(rawValue: "recordA. member"))

--- a/Tests/VHDLParsingTests/MemberAccessTests.swift
+++ b/Tests/VHDLParsingTests/MemberAccessTests.swift
@@ -83,6 +83,11 @@ final class MemberAccessTests: XCTestCase {
     /// Test the `rawValue` generates the correct String.
     func testRawValue() {
         XCTAssertEqual(memberAccess.rawValue, "recordA.member")
+        let member2 = MemberAccess(
+            record: record,
+            member: .member(access: MemberAccess(record: VariableName(text: "record2"), member: member))
+        )
+        XCTAssertEqual(member2.rawValue, "recordA.record2.member")
     }
 
     /// Test `init(rawValue:)` correctly parses the string.

--- a/Tests/VHDLParsingTests/MemberAccessTests.swift
+++ b/Tests/VHDLParsingTests/MemberAccessTests.swift
@@ -110,6 +110,8 @@ final class MemberAccessTests: XCTestCase {
         XCTAssertNil(MemberAccess(rawValue: "recordA .member"))
         XCTAssertNil(MemberAccess(rawValue: "recordA . member"))
         XCTAssertNil(MemberAccess(rawValue: "recordA. member"))
+        XCTAssertNil(MemberAccess(rawValue: ""))
+        XCTAssertNil(MemberAccess(rawValue: " "))
         XCTAssertNil(MemberAccess(rawValue: "."))
         XCTAssertNil(MemberAccess(rawValue: "recordA."))
         XCTAssertNil(MemberAccess(rawValue: ".member"))

--- a/Tests/VHDLParsingTests/PortMapTests.swift
+++ b/Tests/VHDLParsingTests/PortMapTests.swift
@@ -61,13 +61,13 @@ import XCTest
 final class PortMapTests: XCTestCase {
 
     /// A variable `x`.
-    let x = VariableReference.variable(name: VariableName(text: "x"))
+    let x = VariableReference.variable(reference: .variable(name: VariableName(text: "x")))
 
     /// A variable `y`.
-    let y = VariableReference.variable(name: VariableName(text: "y"))
+    let y = VariableReference.variable(reference: .variable(name: VariableName(text: "y")))
 
     /// A variable `z`.
-    let z = VariableReference.variable(name: VariableName(text: "z"))
+    let z = VariableReference.variable(reference: .variable(name: VariableName(text: "z")))
 
     /// The `PortMap` under test.
     lazy var map = PortMap(

--- a/Tests/VHDLParsingTests/ProcessBlockTests.swift
+++ b/Tests/VHDLParsingTests/ProcessBlockTests.swift
@@ -73,10 +73,13 @@ final class ProcessBlockTests: XCTestCase {
     var code: SynchronousBlock {
         .ifStatement(block: .ifStatement(
             condition: .conditional(
-                condition: .edge(value: .rising(expression: .reference(variable: .variable(name: clk))))
+                condition: .edge(value: .rising(expression: .reference(
+                    variable: .variable(reference: .variable(name: clk))
+                )))
             ),
             ifBlock: .statement(statement: .assignment(
-                name: .variable(name: x), value: .reference(variable: .variable(name: y))
+                name: .variable(reference: .variable(name: x)),
+                value: .reference(variable: .variable(reference: .variable(name: y)))
             ))
         ))
     }

--- a/Tests/VHDLParsingTests/StatementTests.swift
+++ b/Tests/VHDLParsingTests/StatementTests.swift
@@ -67,7 +67,7 @@ final class StatementTests: XCTestCase {
     func testRawValue() {
         XCTAssertEqual(
             Statement.assignment(
-                name: .variable(name: varX), value: .literal(value: .bit(value: .high))
+                name: .variable(reference: .variable(name: varX)), value: .literal(value: .bit(value: .high))
             ).rawValue,
             "x <= '1';"
         )
@@ -105,25 +105,32 @@ final class StatementTests: XCTestCase {
     func testAssignmentRawValueInit() {
         let value = Expression.literal(value: .bit(value: .high))
         XCTAssertEqual(
-            Statement(rawValue: "x <= '1';"), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: "x <= '1';"),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertEqual(
-            Statement(rawValue: "x <= '1'; "), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: "x <= '1'; "),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertEqual(
-            Statement(rawValue: " x <= '1';"), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: " x <= '1';"),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertEqual(
-            Statement(rawValue: " x <= '1'; "), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: " x <= '1'; "),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertEqual(
-            Statement(rawValue: "x <= '1';\n"), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: "x <= '1';\n"),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertEqual(
-            Statement(rawValue: "x <= '1';\n "), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: "x <= '1';\n "),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertEqual(
-            Statement(rawValue: "x   <=    '1' ; "), .assignment(name: .variable(name: varX), value: value)
+            Statement(rawValue: "x   <=    '1' ; "),
+            .assignment(name: .variable(reference: .variable(name: varX)), value: value)
         )
         XCTAssertNil(Statement(rawValue: "x <= '1' <= '0';"))
         XCTAssertNil(Statement(rawValue: "x <= '2';"))

--- a/Tests/VHDLParsingTests/SynchronousBlockTests.swift
+++ b/Tests/VHDLParsingTests/SynchronousBlockTests.swift
@@ -57,8 +57,6 @@
 @testable import VHDLParsing
 import XCTest
 
-// swiftlint:disable type_body_length
-
 /// Test class for ``SynchronousBlock``
 final class SynchronousBlockTests: XCTestCase {
 
@@ -72,20 +70,21 @@ final class SynchronousBlockTests: XCTestCase {
     func testRawValues() {
         let statement = SynchronousBlock.statement(
             statement: Statement.assignment(
-                name: .variable(name: x), value: .literal(value: .bit(value: .high))
+                name: .variable(reference: .variable(name: x)), value: .literal(value: .bit(value: .high))
             )
         )
         XCTAssertEqual(statement.rawValue, "x <= '1';")
         let ifStatement = SynchronousBlock.ifStatement(block: .ifStatement(
             condition: .conditional(
                 condition: .comparison(value: .equality(
-                    lhs: .reference(variable: .variable(name: x)),
-                    rhs: .reference(variable: .variable(name: y))
+                    lhs: .reference(variable: .variable(reference: .variable(name: x))),
+                    rhs: .reference(variable: .variable(reference: .variable(name: y)))
                 ))
             ),
             ifBlock: SynchronousBlock.statement(
                 statement: Statement.assignment(
-                    name: .variable(name: x), value: .reference(variable: .variable(name: y))
+                    name: .variable(reference: .variable(name: x)),
+                    value: .reference(variable: .variable(reference: .variable(name: y)))
                 )
             )
         ))
@@ -119,18 +118,20 @@ final class SynchronousBlockTests: XCTestCase {
         end case;
         """
         let caseStatement = SynchronousBlock.caseStatement(block: CaseStatement(
-            condition: .reference(variable: .variable(name: x)),
+            condition: .reference(variable: .variable(reference: .variable(name: x))),
             cases: [
                 WhenCase(
                     condition: .expression(expression: .literal(value: .bit(value: .high))),
                     code: .statement(statement: .assignment(
-                        name: .variable(name: y), value: .literal(value: .bit(value: .high))
+                        name: .variable(reference: .variable(name: y)),
+                        value: .literal(value: .bit(value: .high))
                     ))
                 ),
                 WhenCase(
                     condition: .expression(expression: .literal(value: .bit(value: .low))),
                     code: .statement(statement: .assignment(
-                        name: .variable(name: y), value: .literal(value: .bit(value: .low))
+                        name: .variable(reference: .variable(name: y)),
+                        value: .literal(value: .bit(value: .low))
                     ))
                 )
             ]
@@ -142,7 +143,7 @@ final class SynchronousBlockTests: XCTestCase {
     func testStatementRawValueInit() {
         let expected = SynchronousBlock.statement(
             statement: Statement.assignment(
-                name: .variable(name: x), value: .literal(value: .bit(value: .high))
+                name: .variable(reference: .variable(name: x)), value: .literal(value: .bit(value: .high))
             )
         )
         XCTAssertEqual(SynchronousBlock(rawValue: "x <= '1';"), expected)
@@ -162,14 +163,16 @@ final class SynchronousBlockTests: XCTestCase {
 
     /// Test if statement raw value initialiser.
     func testIfRawValueInit() {
-        let x = Expression.reference(variable: .variable(name: x))
-        let y = Expression.reference(variable: .variable(name: y))
+        let x = Expression.reference(variable: .variable(reference: .variable(name: x)))
+        let y = Expression.reference(variable: .variable(reference: .variable(name: y)))
         let expected = SynchronousBlock.ifStatement(block: IfBlock.ifElse(
             condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
             ifBlock: .blocks(
                 blocks: [
                     .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                        )
                     ),
                     .ifStatement(
                         block: IfBlock.ifStatement(
@@ -180,7 +183,7 @@ final class SynchronousBlockTests: XCTestCase {
                             ),
                             ifBlock: .statement(
                                 statement: .assignment(
-                                    name: .variable(name: VariableName(text: "x")),
+                                    name: .variable(reference: .variable(name: VariableName(text: "x"))),
                                     value: .literal(value: .bit(value: .low))
                                 )
                             )
@@ -192,11 +195,11 @@ final class SynchronousBlockTests: XCTestCase {
                 block: .ifElse(
                     condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
                     ifBlock: .statement(statement: .assignment(
-                        name: .variable(name: VariableName(text: "y")), value: x
+                        name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
                     )),
                     elseBlock: .statement(
                         statement: .assignment(
-                            name: .variable(name: VariableName(text: "x")),
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))),
                             value: .literal(value: .bit(value: .low))
                         )
                     )
@@ -224,7 +227,7 @@ final class SynchronousBlockTests: XCTestCase {
     func testMultipleStatementsRawValueInit() {
         let statement = SynchronousBlock.statement(
             statement: Statement.assignment(
-                name: .variable(name: x), value: .literal(value: .bit(value: .high))
+                name: .variable(reference: .variable(name: x)), value: .literal(value: .bit(value: .high))
             )
         )
         let expected = SynchronousBlock.blocks(blocks: [statement, statement])
@@ -243,249 +246,4 @@ final class SynchronousBlockTests: XCTestCase {
         XCTAssertNil(SynchronousBlock(rawValue: "\(String(repeating: "x", count: 4096)) <= '1';"))
     }
 
-    // swiftlint:disable function_body_length
-
-    /// Test statement and if blocks together.
-    func testMixedRawValueInit() {
-        let x = Expression.reference(variable: .variable(name: x))
-        let y = Expression.reference(variable: .variable(name: y))
-        let ifStatement = SynchronousBlock.ifStatement(block: IfBlock.ifElse(
-            condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
-            ifBlock: .blocks(
-                blocks: [
-                    .statement(
-                        statement: .assignment(name: .variable(name: VariableName(text: "x")), value: y)
-                    ),
-                    .ifStatement(
-                        block: IfBlock.ifStatement(
-                            condition: .conditional(
-                                condition: .comparison(
-                                    value: .equality(lhs: x, rhs: .literal(value: .bit(value: .high)))
-                                )
-                            ),
-                            ifBlock: .statement(
-                                statement: .assignment(
-                                    name: .variable(name: VariableName(text: "x")),
-                                    value: .literal(value: .bit(value: .low))
-                                )
-                            )
-                        )
-                    )
-                ]
-            ),
-            elseBlock: .ifStatement(
-                block: .ifElse(
-                    condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
-                    ifBlock: .statement(statement: .assignment(
-                        name: .variable(name: VariableName(text: "y")), value: x
-                    )),
-                    elseBlock: .statement(
-                        statement: .assignment(
-                            name: .variable(name: VariableName(text: "x")),
-                            value: .literal(value: .bit(value: .low))
-                        )
-                    )
-                )
-            )
-        ))
-        let assignment = SynchronousBlock.statement(
-            statement: .assignment(name: .variable(name: self.x), value: .literal(value: .bit(value: .high)))
-        )
-        let raw = """
-        x <= '1';
-        if (x = y) then
-            x <= y;
-            if (x = '1') then
-                x <= '0';
-            end if;
-        elsif (x /= y) then
-            y <= x;
-        else
-            x <= '0';
-        end if;
-        """
-        XCTAssertEqual(SynchronousBlock(rawValue: raw), .blocks(blocks: [assignment, ifStatement]))
-    }
-
-    /// Test statement and if blocks together.
-    func testMixedRawValueInit2() {
-        let x = Expression.reference(variable: .variable(name: x))
-        let y = Expression.reference(variable: .variable(name: y))
-        let ifStatement = SynchronousBlock.ifStatement(block: IfBlock.ifElse(
-            condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
-            ifBlock: .blocks(
-                blocks: [
-                    .statement(statement: .assignment(name: .variable(name: self.x), value: y)),
-                    .ifStatement(
-                        block: IfBlock.ifStatement(
-                            condition: .conditional(
-                                condition: .comparison(
-                                    value: .equality(lhs: x, rhs: .literal(value: .bit(value: .high)))
-                                )
-                            ),
-                            ifBlock: .statement(
-                                statement: .assignment(
-                                    name: .variable(name: self.x), value: .literal(value: .bit(value: .low))
-                                )
-                            )
-                        )
-                    )
-                ]
-            ),
-            elseBlock: .ifStatement(
-                block: .ifElse(
-                    condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
-                    ifBlock: .statement(statement: .assignment(name: .variable(name: self.y), value: x)),
-                    elseBlock: .statement(
-                        statement: .assignment(
-                            name: .variable(name: self.x), value: .literal(value: .bit(value: .low))
-                        )
-                    )
-                )
-            )
-        ))
-        let assignment = SynchronousBlock.statement(
-            statement: .assignment(name: .variable(name: self.x), value: .literal(value: .bit(value: .high)))
-        )
-        let raw = """
-        x <= '1';
-        if (x = y) then
-            x <= y;
-            if (x = '1') then
-                x <= '0';
-            end if;
-        elsif (x /= y) then
-            y <= x;
-        else
-            x <= '0';
-        end if;
-        x <= '1';
-        """
-        let result = SynchronousBlock(rawValue: raw)
-        XCTAssertEqual(result, .blocks(blocks: [assignment, ifStatement, assignment]))
-    }
-
-    // swiftlint:enable function_body_length
-
-    /// Test multiple statements in a block.
-    func testMultipleStatementRawValueInit() {
-        let raw = """
-        x <= '0';
-        x <= '1';
-        y <= x;
-        """
-        let expected = SynchronousBlock.blocks(blocks: [
-            .statement(statement: .assignment(
-                name: .variable(name: self.x), value: .literal(value: .bit(value: .low))
-            )),
-            .statement(statement: .assignment(
-                name: .variable(name: self.x), value: .literal(value: .bit(value: .high))
-            )),
-            .statement(statement: .assignment(
-                name: .variable(name: self.y),
-                value: .reference(variable: .variable(name: VariableName(text: "x")))
-            ))
-        ])
-        XCTAssertEqual(SynchronousBlock(rawValue: raw), expected)
-    }
-
-    /// Test case raw value init.
-    func testCaseRawValueInit() {
-        let raw = """
-        case x is
-            when '1' =>
-                y <= '1';
-            when '0' =>
-                y <= '0';
-        end case;
-        """
-        let caseStatement = SynchronousBlock.caseStatement(block: CaseStatement(
-            condition: .reference(variable: .variable(name: x)),
-            cases: [
-                WhenCase(
-                    condition: .expression(expression: .literal(value: .bit(value: .high))),
-                    code: .statement(statement: .assignment(
-                        name: .variable(name: y), value: .literal(value: .bit(value: .high))
-                    ))
-                ),
-                WhenCase(
-                    condition: .expression(expression: .literal(value: .bit(value: .low))),
-                    code: .statement(statement: .assignment(
-                        name: .variable(name: y), value: .literal(value: .bit(value: .low))
-                    ))
-                )
-            ]
-        ))
-        XCTAssertEqual(SynchronousBlock(rawValue: raw), caseStatement)
-        let raw2 = """
-        x <= '0';
-        x <= '0';
-        case x is
-            when '1' =>
-                y <= '1';
-            when '0' =>
-                y <= '0';
-        end case;
-        x <= '0';
-        x <= '0';
-        """
-        let assignment = SynchronousBlock.statement(
-            statement: .assignment(name: .variable(name: self.x), value: .literal(value: .bit(value: .low)))
-        )
-        let blocks = [assignment, assignment, caseStatement, assignment, assignment]
-        let expected = SynchronousBlock.blocks(blocks: blocks)
-        XCTAssertEqual(SynchronousBlock(rawValue: raw2), expected)
-    }
-
-    /// Test invalid case statement.
-    func testInvalidCaseStatement() {
-        let raw = """
-        x <= '0';
-        x <= '0';
-        case x is
-            when '1' =>
-                y <= '1';
-            when '0' =>
-                y <= '0';
-        x <= '0';
-        x <= '0';
-        """
-        XCTAssertNil(SynchronousBlock(rawValue: raw))
-    }
-
-    /// Test for loop creation.
-    func testForLoop() {
-        let raw = """
-        for x in 0 to 7 loop
-            y <= x;
-        end loop;
-        """
-        let expected = SynchronousBlock.forLoop(loop: ForLoop(
-            iterator: x,
-            range: .to(
-                lower: .literal(value: .integer(value: 0)), upper: .literal(value: .integer(value: 7))
-            ),
-            body: .statement(statement: .assignment(
-                name: .variable(name: y), value: .reference(variable: .variable(name: x))
-            ))
-        ))
-        XCTAssertEqual(SynchronousBlock(rawValue: raw), expected)
-        let raw2 = """
-        y <= x;
-        \(raw)
-        x <= y;
-        """
-        let yAssignment = SynchronousBlock.statement(
-            statement: .assignment(name: .variable(name: y), value: .reference(variable: .variable(name: x)))
-        )
-        let xAssignment = SynchronousBlock.statement(
-            statement: .assignment(name: .variable(name: x), value: .reference(variable: .variable(name: y)))
-        )
-        XCTAssertEqual(
-            SynchronousBlock(rawValue: raw2), .blocks(blocks: [yAssignment, expected, xAssignment])
-        )
-    }
-
 }
-
-// swiftlint:enable type_body_length

--- a/Tests/VHDLParsingTests/SynchronousBlockTests2.swift
+++ b/Tests/VHDLParsingTests/SynchronousBlockTests2.swift
@@ -1,0 +1,339 @@
+// SynchronousBlockTests2.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLParsing
+import XCTest
+
+/// Test class for ``SynchronousBlock``
+final class SynchronousBlockTests2: XCTestCase {
+
+    /// A variable called x.
+    let x = VariableName(text: "x")
+
+    /// A variable called y.
+    let y = VariableName(text: "y")
+
+    // swiftlint:disable function_body_length
+
+    /// Test statement and if blocks together.
+    func testMixedRawValueInit() {
+        let x = Expression.reference(variable: .variable(reference: .variable(name: x)))
+        let y = Expression.reference(variable: .variable(reference: .variable(name: y)))
+        let ifStatement = SynchronousBlock.ifStatement(block: IfBlock.ifElse(
+            condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
+            ifBlock: .blocks(
+                blocks: [
+                    .statement(
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))), value: y
+                        )
+                    ),
+                    .ifStatement(
+                        block: IfBlock.ifStatement(
+                            condition: .conditional(
+                                condition: .comparison(
+                                    value: .equality(lhs: x, rhs: .literal(value: .bit(value: .high)))
+                                )
+                            ),
+                            ifBlock: .statement(
+                                statement: .assignment(
+                                    name: .variable(reference: .variable(name: VariableName(text: "x"))),
+                                    value: .literal(value: .bit(value: .low))
+                                )
+                            )
+                        )
+                    )
+                ]
+            ),
+            elseBlock: .ifStatement(
+                block: .ifElse(
+                    condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
+                    ifBlock: .statement(statement: .assignment(
+                        name: .variable(reference: .variable(name: VariableName(text: "y"))), value: x
+                    )),
+                    elseBlock: .statement(
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: VariableName(text: "x"))),
+                            value: .literal(value: .bit(value: .low))
+                        )
+                    )
+                )
+            )
+        ))
+        let assignment = SynchronousBlock.statement(
+            statement: .assignment(
+                name: .variable(reference: .variable(name: self.x)),
+                value: .literal(value: .bit(value: .high))
+            )
+        )
+        let raw = """
+        x <= '1';
+        if (x = y) then
+            x <= y;
+            if (x = '1') then
+                x <= '0';
+            end if;
+        elsif (x /= y) then
+            y <= x;
+        else
+            x <= '0';
+        end if;
+        """
+        XCTAssertEqual(SynchronousBlock(rawValue: raw), .blocks(blocks: [assignment, ifStatement]))
+    }
+
+    /// Test statement and if blocks together.
+    func testMixedRawValueInit2() {
+        let x = Expression.reference(variable: .variable(reference: .variable(name: x)))
+        let y = Expression.reference(variable: .variable(reference: .variable(name: y)))
+        let ifStatement = SynchronousBlock.ifStatement(block: IfBlock.ifElse(
+            condition: .conditional(condition: .comparison(value: .equality(lhs: x, rhs: y))),
+            ifBlock: .blocks(
+                blocks: [
+                    .statement(statement: .assignment(
+                        name: .variable(reference: .variable(name: self.x)), value: y
+                    )),
+                    .ifStatement(
+                        block: IfBlock.ifStatement(
+                            condition: .conditional(
+                                condition: .comparison(
+                                    value: .equality(lhs: x, rhs: .literal(value: .bit(value: .high)))
+                                )
+                            ),
+                            ifBlock: .statement(
+                                statement: .assignment(
+                                    name: .variable(reference: .variable(name: self.x)),
+                                    value: .literal(value: .bit(value: .low))
+                                )
+                            )
+                        )
+                    )
+                ]
+            ),
+            elseBlock: .ifStatement(
+                block: .ifElse(
+                    condition: .conditional(condition: .comparison(value: .notEquals(lhs: x, rhs: y))),
+                    ifBlock: .statement(statement: .assignment(
+                        name: .variable(reference: .variable(name: self.y)), value: x
+                    )),
+                    elseBlock: .statement(
+                        statement: .assignment(
+                            name: .variable(reference: .variable(name: self.x)),
+                            value: .literal(value: .bit(value: .low))
+                        )
+                    )
+                )
+            )
+        ))
+        let assignment = SynchronousBlock.statement(
+            statement: .assignment(
+                name: .variable(reference: .variable(name: self.x)),
+                value: .literal(value: .bit(value: .high))
+            )
+        )
+        let raw = """
+        x <= '1';
+        if (x = y) then
+            x <= y;
+            if (x = '1') then
+                x <= '0';
+            end if;
+        elsif (x /= y) then
+            y <= x;
+        else
+            x <= '0';
+        end if;
+        x <= '1';
+        """
+        let result = SynchronousBlock(rawValue: raw)
+        XCTAssertEqual(result, .blocks(blocks: [assignment, ifStatement, assignment]))
+    }
+
+    // swiftlint:enable function_body_length
+
+    /// Test multiple statements in a block.
+    func testMultipleStatementRawValueInit() {
+        let raw = """
+        x <= '0';
+        x <= '1';
+        y <= x;
+        """
+        let expected = SynchronousBlock.blocks(blocks: [
+            .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: self.x)), value: .literal(value: .bit(value: .low))
+            )),
+            .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: self.x)),
+                value: .literal(value: .bit(value: .high))
+            )),
+            .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: self.y)),
+                value: .reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
+            ))
+        ])
+        XCTAssertEqual(SynchronousBlock(rawValue: raw), expected)
+    }
+
+    /// Test case raw value init.
+    func testCaseRawValueInit() {
+        let raw = """
+        case x is
+            when '1' =>
+                y <= '1';
+            when '0' =>
+                y <= '0';
+        end case;
+        """
+        let caseStatement = SynchronousBlock.caseStatement(block: CaseStatement(
+            condition: .reference(variable: .variable(reference: .variable(name: x))),
+            cases: [
+                WhenCase(
+                    condition: .expression(expression: .literal(value: .bit(value: .high))),
+                    code: .statement(statement: .assignment(
+                        name: .variable(reference: .variable(name: y)),
+                        value: .literal(value: .bit(value: .high))
+                    ))
+                ),
+                WhenCase(
+                    condition: .expression(expression: .literal(value: .bit(value: .low))),
+                    code: .statement(statement: .assignment(
+                        name: .variable(reference: .variable(name: y)),
+                        value: .literal(value: .bit(value: .low))
+                    ))
+                )
+            ]
+        ))
+        XCTAssertEqual(SynchronousBlock(rawValue: raw), caseStatement)
+        let raw2 = """
+        x <= '0';
+        x <= '0';
+        case x is
+            when '1' =>
+                y <= '1';
+            when '0' =>
+                y <= '0';
+        end case;
+        x <= '0';
+        x <= '0';
+        """
+        let assignment = SynchronousBlock.statement(
+            statement: .assignment(
+                name: .variable(reference: .variable(name: self.x)),
+                value: .literal(value: .bit(value: .low))
+            )
+        )
+        let blocks = [assignment, assignment, caseStatement, assignment, assignment]
+        let expected = SynchronousBlock.blocks(blocks: blocks)
+        XCTAssertEqual(SynchronousBlock(rawValue: raw2), expected)
+    }
+
+    /// Test invalid case statement.
+    func testInvalidCaseStatement() {
+        let raw = """
+        x <= '0';
+        x <= '0';
+        case x is
+            when '1' =>
+                y <= '1';
+            when '0' =>
+                y <= '0';
+        x <= '0';
+        x <= '0';
+        """
+        XCTAssertNil(SynchronousBlock(rawValue: raw))
+    }
+
+    /// Test for loop creation.
+    func testForLoop() {
+        let raw = """
+        for x in 0 to 7 loop
+            y <= x;
+        end loop;
+        """
+        let expected = SynchronousBlock.forLoop(loop: ForLoop(
+            iterator: x,
+            range: .to(
+                lower: .literal(value: .integer(value: 0)), upper: .literal(value: .integer(value: 7))
+            ),
+            body: .statement(statement: .assignment(
+                name: .variable(reference: .variable(name: y)),
+                value: .reference(variable: .variable(reference: .variable(name: x)))
+            ))
+        ))
+        XCTAssertEqual(SynchronousBlock(rawValue: raw), expected)
+        let raw2 = """
+        y <= x;
+        \(raw)
+        x <= y;
+        """
+        let yAssignment = SynchronousBlock.statement(
+            statement: .assignment(
+                name: .variable(reference: .variable(name: y)),
+                value: .reference(variable: .variable(reference: .variable(name: x)))
+            )
+        )
+        let xAssignment = SynchronousBlock.statement(
+            statement: .assignment(
+                name: .variable(reference: .variable(name: x)),
+                value: .reference(variable: .variable(reference: .variable(name: y)))
+            )
+        )
+        XCTAssertEqual(
+            SynchronousBlock(rawValue: raw2), .blocks(blocks: [yAssignment, expected, xAssignment])
+        )
+    }
+
+}

--- a/Tests/VHDLParsingTests/VHDLFileTests.swift
+++ b/Tests/VHDLParsingTests/VHDLFileTests.swift
@@ -90,12 +90,14 @@ final class VHDLFileTests: XCTestCase {
                 code: .ifStatement(block: .ifStatement(
                     condition: .conditional(condition: .edge(
                         value: .rising(expression: .reference(
-                            variable: .variable(name: VariableName(text: "clk"))
+                            variable: .variable(reference: .variable(name: VariableName(text: "clk")))
                         ))
                     )),
                     ifBlock: .statement(statement: .assignment(
-                        name: .variable(name: VariableName(text: "y")),
-                        value: .reference(variable: .variable(name: VariableName(text: "x")))
+                        name: .variable(reference: .variable(name: VariableName(text: "y"))),
+                        value: .reference(
+                            variable: .variable(reference: .variable(name: VariableName(text: "x")))
+                        )
                     ))
                 ))
             )),

--- a/Tests/VHDLParsingTests/VariableAssignmentTests.swift
+++ b/Tests/VHDLParsingTests/VariableAssignmentTests.swift
@@ -61,7 +61,7 @@ import XCTest
 final class VariableAssignmentTests: XCTestCase {
 
     /// A variable `x`.
-    let x = VariableReference.variable(name: VariableName(text: "x"))
+    let x = VariableReference.variable(reference: .variable(name: VariableName(text: "x")))
 
     /// The assignment under test.
     lazy var assignment = VariableAssignment.reference(variable: x)

--- a/Tests/VHDLParsingTests/VariableMapTests.swift
+++ b/Tests/VHDLParsingTests/VariableMapTests.swift
@@ -61,10 +61,12 @@ import XCTest
 final class VariableMapTests: XCTestCase {
 
     /// A variable `x`.
-    let x = VariableReference.variable(name: VariableName(text: "x"))
+    let x = VariableReference.variable(reference: .variable(name: VariableName(text: "x")))
 
     /// A variable `y`.
-    let y = VariableAssignment.reference(variable: .variable(name: VariableName(text: "y")))
+    let y = VariableAssignment.reference(
+        variable: .variable(reference: .variable(name: VariableName(text: "y")))
+    )
 
     /// The map under test.
     lazy var map = VariableMap(lhs: x, rhs: y)

--- a/Tests/VHDLParsingTests/VariableReferenceTests.swift
+++ b/Tests/VHDLParsingTests/VariableReferenceTests.swift
@@ -67,7 +67,7 @@ final class VariableReferenceTests: XCTestCase {
     let index = VectorIndex.index(value: .literal(value: .integer(value: 5)))
 
     /// A reference of `x`.
-    lazy var variable = VariableReference.variable(name: x)
+    lazy var variable = VariableReference.variable(reference: .variable(name: x))
 
     /// An indexed reference of `x`.
     lazy var indexed = VariableReference.indexed(name: x, index: index)
@@ -75,7 +75,7 @@ final class VariableReferenceTests: XCTestCase {
     /// Initialise the test data before each test case.
     override func setUp() {
         super.setUp()
-        variable = VariableReference.variable(name: x)
+        variable = .variable(reference: .variable(name: x))
         indexed = VariableReference.indexed(name: x, index: index)
     }
 

--- a/Tests/VHDLParsingTests/VectorIndexTests.swift
+++ b/Tests/VHDLParsingTests/VectorIndexTests.swift
@@ -81,7 +81,9 @@ final class VectorIndexTests: XCTestCase {
         XCTAssertEqual(VectorIndex(rawValue: "11"), .index(value: .literal(value: .integer(value: 11))))
         XCTAssertEqual(
             VectorIndex(rawValue: "A"),
-            .index(value: .reference(variable: .variable(name: VariableName(text: "A"))))
+            .index(value: .reference(
+                variable: .variable(reference: .variable(name: VariableName(text: "A")))
+            ))
         )
         XCTAssertNil(VectorIndex(rawValue: "1 2"))
         XCTAssertNil(VectorIndex(rawValue: "-1"))
@@ -103,11 +105,15 @@ final class VectorIndexTests: XCTestCase {
         XCTAssertEqual(VectorIndex(rawValue: "OtHErS"), .others)
         XCTAssertEqual(
             VectorIndex(rawValue: "otherss"),
-            .index(value: .reference(variable: .variable(name: VariableName(text: "otherss"))))
+            .index(value: .reference(
+                variable: .variable(reference: .variable(name: VariableName(text: "otherss")))
+            ))
         )
         XCTAssertEqual(
             VectorIndex(rawValue: "other"),
-            .index(value: .reference(variable: .variable(name: VariableName(text: "other"))))
+            .index(value: .reference(
+                variable: .variable(reference: .variable(name: VariableName(text: "other")))
+            ))
         )
     }
 

--- a/Tests/VHDLParsingTests/VectorSizeTests.swift
+++ b/Tests/VHDLParsingTests/VectorSizeTests.swift
@@ -112,7 +112,7 @@ final class VectorSizeTests: XCTestCase {
         XCTAssertEqual(
             VectorSize(rawValue: raw),
             .downto(
-                upper: .reference(variable: .variable(name: VariableName(text: "a"))),
+                upper: .reference(variable: .variable(reference: .variable(name: VariableName(text: "a")))),
                 lower: .literal(value: .integer(value: 4))
             )
         )
@@ -125,7 +125,7 @@ final class VectorSizeTests: XCTestCase {
             VectorSize(rawValue: raw),
             .to(
                 lower: .literal(value: .integer(value: 2)),
-                upper: .reference(variable: .variable(name: VariableName(text: "b")))
+                upper: .reference(variable: .variable(reference: .variable(name: VariableName(text: "b"))))
             )
         )
     }

--- a/Tests/VHDLParsingTests/WhenConditionTests.swift
+++ b/Tests/VHDLParsingTests/WhenConditionTests.swift
@@ -112,7 +112,7 @@ final class WhenConditionTests: XCTestCase {
     /// Test init for expression case.
     func testExpressionInit() {
         let expected = WhenCondition.expression(
-            expression: .reference(variable: .variable(name: VariableName(text: "x")))
+            expression: .reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
         )
         XCTAssertEqual(WhenCondition(rawValue: "x"), expected)
         XCTAssertEqual(WhenCondition(rawValue: "x "), expected)


### PR DESCRIPTION
This PR creates new types for declaring and parsing `VHDL` code that access members within record instances. This also changes the `VariableReference` type to incorporate this new capability.