### PR TITLE
Made VariableReference work with Expressions

### DIFF
--- a/Sources/VHDLParsing/CustomFunctionCall.swift
+++ b/Sources/VHDLParsing/CustomFunctionCall.swift
@@ -65,6 +65,7 @@ public struct CustomFunctionCall: FunctionCallable, Equatable, Hashable, Codable
     public let parameters: [Argument]
 
     /// The arguments passed to the function.
+    @available(*, deprecated)
     @inlinable public var arguments: [Expression] {
         self.parameters.map { $0.argument }
     }
@@ -79,6 +80,7 @@ public struct CustomFunctionCall: FunctionCallable, Equatable, Hashable, Codable
     ///   - function: The function name as a string.
     ///   - arguments: The arguments of the function call.
     @inlinable
+    @available(*, deprecated)
     public init?(function: String, arguments: [Expression]) {
         guard let name = VariableName(rawValue: function) else {
             return nil
@@ -91,6 +93,7 @@ public struct CustomFunctionCall: FunctionCallable, Equatable, Hashable, Codable
     ///   - name: The name of the function.
     ///   - arguments: The arguments of the function call.
     @inlinable
+    @available(*, deprecated)
     public init(name: VariableName, arguments: [Expression]) {
         self.init(name: name, parameters: arguments.map { Argument(argument: $0) })
     }

--- a/Sources/VHDLParsing/FunctionImplementation.swift
+++ b/Sources/VHDLParsing/FunctionImplementation.swift
@@ -91,15 +91,32 @@ public struct FunctionImplementation: RawRepresentable, Equatable, Hashable, Cod
     ///   - returnTube: The return type of the function.
     ///   - body: The body of the function.
     @inlinable
+    @available(*, deprecated)
     public init(
         name: VariableName,
         arguments: [ArgumentDefinition],
         returnTube: Type,
         body: SynchronousBlock
     ) {
+        self.init(name: name, arguments: arguments, returnType: returnTube, body: body)
+    }
+
+    /// Creates a new `FunctionImplementation` instance from its properties.
+    /// - Parameters:
+    ///   - name: The name of the function.
+    ///   - arguments: The arguments of the function.
+    ///   - returnTube: The return type of the function.
+    ///   - body: The body of the function.
+    @inlinable
+    public init(
+        name: VariableName,
+        arguments: [ArgumentDefinition],
+        returnType: Type,
+        body: SynchronousBlock
+    ) {
         self.name = name
         self.arguments = arguments
-        self.returnType = returnTube
+        self.returnType = returnType
         self.body = body
     }
 
@@ -112,7 +129,7 @@ public struct FunctionImplementation: RawRepresentable, Equatable, Hashable, Cod
         self.init(
             name: definition.name,
             arguments: definition.arguments,
-            returnTube: definition.returnType,
+            returnType: definition.returnType,
             body: body
         )
     }

--- a/Sources/VHDLParsing/VariableReference.swift
+++ b/Sources/VHDLParsing/VariableReference.swift
@@ -64,7 +64,7 @@ public enum VariableReference: RawRepresentable, Equatable, Hashable, Codable, S
     case variable(reference: DirectReference)
 
     /// Indexing a variable.
-    case indexed(name: VariableName, index: VectorIndex)
+    case indexed(name: Expression, index: VectorIndex)
 
     /// The equivalent `VHDL` code.
     @inlinable public var rawValue: String {
@@ -92,7 +92,7 @@ public enum VariableReference: RawRepresentable, Equatable, Hashable, Codable, S
             return nil
         }
         guard
-            let name = VariableName(rawValue: String(trimmedString[trimmedString.startIndex..<bracketIndex])),
+            let name = Expression(rawValue: String(trimmedString[trimmedString.startIndex..<bracketIndex])),
             let bracketRemaining = trimmedString[bracketIndex...].uptoBalancedBracket,
             bracketRemaining.hasPrefix("("),
             bracketRemaining.hasSuffix(")"),
@@ -102,6 +102,17 @@ public enum VariableReference: RawRepresentable, Equatable, Hashable, Codable, S
             return nil
         }
         self = .indexed(name: name, index: index)
+    }
+
+    /// Create and indexed variable reference to a variable.
+    /// - Parameters:
+    ///   - name: The name of the variable.
+    ///   - index: The index in the variable
+    /// - Returns: The indexed variable reference.
+    @inlinable
+    @available(*, deprecated)
+    public static func indexed(name: VariableName, index: VectorIndex) -> VariableReference {
+        .indexed(name: .reference(variable: .variable(reference: .variable(name: name))), index: index)
     }
 
 }

--- a/Tests/VHDLParsingTests/ExpressionTests.swift
+++ b/Tests/VHDLParsingTests/ExpressionTests.swift
@@ -125,7 +125,7 @@ final class ExpressionTests: XCTestCase {
         XCTAssertEqual(
             Expression(rawValue: "a(3 downto 0) * 5"),
             .binary(operation: .multiplication(
-                lhs: .reference(variable: .indexed(name: aname, index: .range(value: .downto(
+                lhs: .reference(variable: .indexed(name: a, index: .range(value: .downto(
                     upper: .literal(value: .integer(value: 3)), lower: .literal(value: .integer(value: 0))
                 )))),
                 rhs: .literal(value: .integer(value: 5))
@@ -135,7 +135,7 @@ final class ExpressionTests: XCTestCase {
             Expression(rawValue: "5 * a(3 downto 0)"),
             .binary(operation: .multiplication(
                 lhs: .literal(value: .integer(value: 5)),
-                rhs: .reference(variable: .indexed(name: aname, index: .range(value: .downto(
+                rhs: .reference(variable: .indexed(name: a, index: .range(value: .downto(
                         upper: .literal(value: .integer(value: 3)),
                         lower: .literal(value: .integer(value: 0))
                 ))))
@@ -439,10 +439,10 @@ final class ExpressionTests: XCTestCase {
             ).isValidOtherValue
         )
         XCTAssertFalse(Expression.reference(variable: .indexed(
-            name: VariableName(text: "a"), index: .range(value: .downto(upper: a, lower: b))
+            name: a, index: .range(value: .downto(upper: a, lower: b))
         )).isValidOtherValue)
         XCTAssertTrue(Expression.reference(variable: .indexed(
-            name: VariableName(text: "a"), index: .index(value: a)
+            name: a, index: .index(value: a)
         )).isValidOtherValue)
     }
 

--- a/Tests/VHDLParsingTests/VariableReferenceTests.swift
+++ b/Tests/VHDLParsingTests/VariableReferenceTests.swift
@@ -61,13 +61,13 @@ import XCTest
 final class VariableReferenceTests: XCTestCase {
 
     /// A variable called `x`.
-    let x = VariableName(text: "x")
+    let x = Expression.reference(variable: .variable(reference: .variable(name: VariableName(text: "x"))))
 
     /// An index of `x`.
     let index = VectorIndex.index(value: .literal(value: .integer(value: 5)))
 
     /// A reference of `x`.
-    lazy var variable = VariableReference.variable(reference: .variable(name: x))
+    lazy var variable = VariableReference.variable(reference: .variable(name: VariableName(text: "x")))
 
     /// An indexed reference of `x`.
     lazy var indexed = VariableReference.indexed(name: x, index: index)
@@ -75,7 +75,7 @@ final class VariableReferenceTests: XCTestCase {
     /// Initialise the test data before each test case.
     override func setUp() {
         super.setUp()
-        variable = .variable(reference: .variable(name: x))
+        variable = .variable(reference: .variable(name: VariableName(text: "x")))
         indexed = VariableReference.indexed(name: x, index: index)
     }
 


### PR DESCRIPTION
Changed the `indexed` case in `VariableReference` to use `Expression` instead of `VariableName`.