### PR TITLE
Add Support for Generate Expressions

### DIFF
--- a/Sources/StringHelpers/String+VHDLMethods.swift
+++ b/Sources/StringHelpers/String+VHDLMethods.swift
@@ -56,6 +56,8 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+
 /// Add helper methods for VHDL parsing.
 extension String {
 
@@ -502,3 +504,5 @@ extension String {
     }
 
 }
+
+// swiftlint:enable file_length

--- a/Sources/StringHelpers/String+VHDLMethods.swift
+++ b/Sources/StringHelpers/String+VHDLMethods.swift
@@ -405,16 +405,22 @@ extension String {
     /// - Parameter value: The substring to search for.
     /// - Returns: The first index within self that matches the substring.
     @inlinable
-    public func startIndex(for value: String) -> String.Index? {
-        self[self.startIndex..<self.endIndex].startIndex(for: value)
+    public func startIndex(for value: String, isCaseSensitive: Bool = true) -> String.Index? {
+        guard isCaseSensitive else {
+            return self.lowercased().startIndex(for: value.lowercased(), isCaseSensitive: true)
+        }
+        return self[self.startIndex..<self.endIndex].startIndex(for: value)
     }
 
     /// Find the start index for a word.
     /// - Parameter word: The word to search for.
     /// - Returns: The index if the word was found.
     @inlinable
-    public func startIndex(word: String) -> String.Index? {
-        self[self.startIndex..<self.endIndex].startIndex(word: word)
+    public func startIndex(word: String, isCaseSensitive: Bool = true) -> String.Index? {
+        guard isCaseSensitive else {
+            return self.lowercased().startIndex(word: word.lowercased(), isCaseSensitive: true)
+        }
+        return self[self.startIndex..<self.endIndex].startIndex(word: word)
     }
 
     /// Find the substrings that start with a given sentence and end with a given sentence. This method also

--- a/Sources/VHDLParsing/ForGenerate.swift
+++ b/Sources/VHDLParsing/ForGenerate.swift
@@ -68,7 +68,7 @@ public struct ForGenerate: RawRepresentable, Equatable, Hashable, Codable, Senda
         """
         \(label.rawValue): for \(iterator.rawValue) in \(range.rawValue) generate
         \(body.rawValue.indent(amount: 1))
-        end generate \(label.rawValue)
+        end generate \(label.rawValue);
         """
     }
 

--- a/Sources/VHDLParsing/ForGenerate.swift
+++ b/Sources/VHDLParsing/ForGenerate.swift
@@ -1,0 +1,86 @@
+// ForGenerate.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+public struct ForGenerate: RawRepresentable, Equatable, Hashable, Codable, Sendable {
+
+    public let label: VariableName
+
+    public let iterator: VariableName
+
+    public let range: VectorSize
+
+    public let body: AsynchronousBlock
+
+    public var rawValue: String {
+        """
+        \(label.rawValue): for \(iterator.rawValue) in \(range.rawValue) generate
+        \(body.rawValue.indent(amount: 1))
+        end generate \(label.rawValue)
+        """
+    }
+
+    public init(label: VariableName, iterator: VariableName, range: VectorSize, body: AsynchronousBlock) {
+        self.label = label
+        self.iterator = iterator
+        self.range = range
+        self.body = body
+    }
+
+    public init?(rawValue: String) {
+        nil
+    }
+
+}

--- a/Sources/VHDLParsing/ForGenerate.swift
+++ b/Sources/VHDLParsing/ForGenerate.swift
@@ -57,17 +57,31 @@
 import Foundation
 import StringHelpers
 
+/// A generate expression utilising a `For` loop.
+/// 
+/// The for of this generate expression is:
+/// ```VHDL
+/// <label>: for <iterator> in <range> generate
+///     <body>
+/// end generate <label>;
+/// ```
+/// - SeeAlso: ``VariableName``, ``VectorSize``, ``AsynchronousBlock``.
 public struct ForGenerate: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 
+    /// The label of the generate expression.
     public let label: VariableName
 
+    /// The iterator in the for-loop of this generate expression.
     public let iterator: VariableName
 
+    /// The range the iterator will iterate over.
     public let range: VectorSize
 
+    /// The body of the for-loop.
     public let body: AsynchronousBlock
 
-    public var rawValue: String {
+    /// The equivalent `VHDL` code enacting this generate statement.
+    @inlinable public var rawValue: String {
         """
         \(label.rawValue): for \(iterator.rawValue) in \(range.rawValue) generate
         \(body.rawValue.indent(amount: 1))
@@ -75,6 +89,13 @@ public struct ForGenerate: RawRepresentable, Equatable, Hashable, Codable, Senda
         """
     }
 
+    /// Creates a new generate expression utilising a `For` loop.
+    /// - Parameters:
+    ///   - label: The label of the generate block.
+    ///   - iterator: The iterator in the for-loop.
+    ///   - range: The range the iterator iterates over.
+    ///   - body: The body of the for-loop.
+    @inlinable
     public init(label: VariableName, iterator: VariableName, range: VectorSize, body: AsynchronousBlock) {
         self.label = label
         self.iterator = iterator
@@ -82,6 +103,11 @@ public struct ForGenerate: RawRepresentable, Equatable, Hashable, Codable, Senda
         self.body = body
     }
 
+    // swiftlint:disable function_body_length
+
+    /// Creates a new generate expression utilising a `For` loop from it's `VHDL` representation.
+    /// - Parameter rawValue: The `VHDL` code enacting this generate statement.
+    @inlinable
     public init?(rawValue: String) {
         let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
@@ -138,5 +164,7 @@ public struct ForGenerate: RawRepresentable, Equatable, Hashable, Codable, Senda
         }
         self.init(label: label, iterator: iterator, range: range, body: body)
     }
+
+    // swiftlint:enable function_body_length
 
 }

--- a/Sources/VHDLParsing/GenerateBlock.swift
+++ b/Sources/VHDLParsing/GenerateBlock.swift
@@ -1,0 +1,88 @@
+// GenerateBlock.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+import Foundation
+import StringHelpers
+
+public enum GenerateBlock: RawRepresentable, Equatable, Hashable, Codable, Sendable {
+
+    case forLoop(block: ForGenerate)
+
+    public var rawValue: String {
+        switch self {
+        case .forLoop(let block):
+            return block.rawValue
+        }
+    }
+
+    public init?(rawValue: String) {
+        let trimmedString = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedString.count < 4096, let withoutColon = trimmedString.split(on: [":"]) else {
+            return nil
+        }
+        let generateRaw = withoutColon.0[1]
+        switch generateRaw.firstWord?.lowercased() {
+        case "for":
+            guard let forGenerate = ForGenerate(rawValue: trimmedString) else {
+                return nil
+            }
+            self = .forLoop(block: forGenerate)
+        default:
+            return nil
+        }
+    }
+
+}

--- a/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
+++ b/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
@@ -71,6 +71,7 @@
 - ``AsynchronousStatement``
 - ``ComponentInstantiation``
 - ``ForGenerate``
+- ``GenerateBlock``
 - ``GenericMap``
 - ``GenericVariableMap``
 - ``PortMap``

--- a/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
+++ b/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
@@ -70,6 +70,7 @@
 - ``AsynchronousExpression``
 - ``AsynchronousStatement``
 - ``ComponentInstantiation``
+- ``ForGenerate``
 - ``GenericMap``
 - ``GenericVariableMap``
 - ``PortMap``

--- a/Tests/VHDLParsingTests/ForGenerateTests.swift
+++ b/Tests/VHDLParsingTests/ForGenerateTests.swift
@@ -1,0 +1,104 @@
+// ForGenerateTests.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2023 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+// 
+
+@testable import VHDLParsing
+import XCTest
+
+/// Test class for ``ForGenerate``.
+final class ForGenerateTests: XCTestCase {
+
+    /// The label.
+    let label = VariableName(text: "generator_inst")
+
+    /// The iterator.
+    let iterator = VariableName(text: "i")
+
+    /// The range.
+    let range = VectorSize.to(
+        lower: .literal(value: .integer(value: 0)), upper: .literal(value: .integer(value: 3))
+    )
+
+    /// The body.
+    let body = AsynchronousBlock.statement(statement: .assignment(
+        name: .indexed(
+            name: .reference(variable: .variable(reference: .variable(name: VariableName(text: "ys")))),
+            index: .index(value: .reference(variable: .variable(
+                reference: .variable(name: VariableName(text: "i"))
+            )))
+        ),
+        value: .expression(value: .reference(variable: .indexed(
+            name: .reference(variable: .variable(reference: .variable(name: VariableName(text: "xs")))),
+            index: .index(value: .reference(variable: .variable(
+                reference: .variable(name: VariableName(text: "i"))
+            )))
+        )))
+    ))
+
+    /// The generate expression under test.
+    var generate: ForGenerate {
+        ForGenerate(label: label, iterator: iterator, range: range, body: body)
+    }
+
+    /// Test the init works correctly.
+    func testPropertyInit() {
+        let generate = generate
+        XCTAssertEqual(generate.label, label)
+        XCTAssertEqual(generate.iterator, iterator)
+        XCTAssertEqual(generate.range, range)
+        XCTAssertEqual(generate.body, body)
+    }
+
+}

--- a/Tests/VHDLParsingTests/ForGenerateTests.swift
+++ b/Tests/VHDLParsingTests/ForGenerateTests.swift
@@ -115,8 +115,84 @@ final class ForGenerateTests: XCTestCase {
 
     /// Test that `init(rawValue:)` parses the `VHDL` code correctly.
     func testRawValueInit() {
-        let result = ForGenerate(rawValue: raw)
-        XCTAssertEqual(result, generate)
+        XCTAssertEqual(ForGenerate(rawValue: raw), generate)
+        XCTAssertEqual(ForGenerate(rawValue: raw.uppercased()), generate)
+        let raw2 = """
+        generator_inst: for \(String(repeating: "i", count: 4096)) in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw2))
+        let raw3 = """
+        !generator_inst: for i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw3))
+        let raw4 = """
+        generator_inst: for i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw4))
+        let raw5 = """
+        generator_inst: fors i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw5))
+        let raw6 = """
+        generator_inst: for !i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw6))
+        let raw7 = """
+        generator_inst: for i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_insts;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw7))
+    }
+
+    /// Test invalid `init(rawValue:)` expression.
+    func testInvalidRawValueInit() {
+        let raw8 = """
+        generator_inst: for i ins 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw8))
+        let raw9 = """
+        generator_inst: for i in 0s to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw9))
+        let raw10 = """
+        generator_inst: for i in 0 to 3 generates
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw10))
+        let raw11 = """
+        generator_inst: for i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generates generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw11))
+        let raw12 = """
+        generator_inst: for i in 0 to 3 generate
+            ys(i) <= xs(i);
+        ends generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw12))
+        let raw13 = """
+        generator_inst: for i in 0 to 3 generate
+            ys(i) <= !xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertNil(ForGenerate(rawValue: raw13))
     }
 
 }

--- a/Tests/VHDLParsingTests/ForGenerateTests.swift
+++ b/Tests/VHDLParsingTests/ForGenerateTests.swift
@@ -101,4 +101,14 @@ final class ForGenerateTests: XCTestCase {
         XCTAssertEqual(generate.body, body)
     }
 
+    /// Test the `rawValue` generates the correct `VHDL` code.
+    func testRawValue() {
+        let expected = """
+        generator_inst: for i in 0 to 3 generate
+            ys(i) <= xs(i);
+        end generate generator_inst;
+        """
+        XCTAssertEqual(generate.rawValue, expected)
+    }
+
 }

--- a/Tests/VHDLParsingTests/ForGenerateTests.swift
+++ b/Tests/VHDLParsingTests/ForGenerateTests.swift
@@ -87,6 +87,13 @@ final class ForGenerateTests: XCTestCase {
         )))
     ))
 
+    /// The raw value.
+    let raw = """
+    generator_inst: for i in 0 to 3 generate
+        ys(i) <= xs(i);
+    end generate generator_inst;
+    """
+
     /// The generate expression under test.
     var generate: ForGenerate {
         ForGenerate(label: label, iterator: iterator, range: range, body: body)
@@ -103,12 +110,13 @@ final class ForGenerateTests: XCTestCase {
 
     /// Test the `rawValue` generates the correct `VHDL` code.
     func testRawValue() {
-        let expected = """
-        generator_inst: for i in 0 to 3 generate
-            ys(i) <= xs(i);
-        end generate generator_inst;
-        """
-        XCTAssertEqual(generate.rawValue, expected)
+        XCTAssertEqual(generate.rawValue, raw)
+    }
+
+    /// Test that `init(rawValue:)` parses the `VHDL` code correctly.
+    func testRawValueInit() {
+        let result = ForGenerate(rawValue: raw)
+        XCTAssertEqual(result, generate)
     }
 
 }

--- a/Tests/VHDLParsingTests/ForGenerateTests.swift
+++ b/Tests/VHDLParsingTests/ForGenerateTests.swift
@@ -54,6 +54,7 @@
 // Fifth Floor, Boston, MA  02110-1301, USA.
 // 
 
+import Foundation
 @testable import VHDLParsing
 import XCTest
 
@@ -115,8 +116,14 @@ final class ForGenerateTests: XCTestCase {
 
     /// Test that `init(rawValue:)` parses the `VHDL` code correctly.
     func testRawValueInit() {
+        let generate = generate
         XCTAssertEqual(ForGenerate(rawValue: raw), generate)
         XCTAssertEqual(ForGenerate(rawValue: raw.uppercased()), generate)
+        XCTAssertEqual(ForGenerate(rawValue: generate.rawValue), generate)
+        XCTAssertEqual(
+            ForGenerate(rawValue: generate.rawValue.trimmingCharacters(in: .whitespacesAndNewlines)),
+            generate
+        )
         let raw2 = """
         generator_inst: for \(String(repeating: "i", count: 4096)) in 0 to 3 generate
             ys(i) <= xs(i);


### PR DESCRIPTION
This PR adds support for defining `generate` expressions. The only supported expression at the moment is the `for-generate` expression, e.g.

```VHDL
<label>: for <iterator> in <range> generate
    <body>
end generate <label>;
```