### PR TITLE
Add support for enumerable type definitions.

### DIFF
--- a/Sources/VHDLParsing/EnumerationDefinition.swift
+++ b/Sources/VHDLParsing/EnumerationDefinition.swift
@@ -56,16 +56,36 @@
 import Foundation
 import StringHelpers
 
+/// A type defined as an enumeration of values.
+/// 
+/// This struct represents a new type definition in `VHDL` that is an enumeration of values. The equivalent
+/// `VHDL` code of this definition is:
+/// ```vhdl
+/// type <name> is (<case0>, <case1>, <case2>, ...);
+/// ```
+/// The number of cases (`values`) within the definition is not limited, but there must be at least 1 case.
 public struct EnumerationDefinition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
 
+    /// The name of the enumeration type.
     public let name: VariableName
 
+    /// The valid values within the enumeration. This array will always contain at least 1 value.
     public let values: [VariableName]
 
-    public var rawValue: String {
+    /// The equivalent `VHDL` code defining this enumeration.
+    @inlinable public var rawValue: String {
         "type \(name.rawValue) is (\(values.map(\.rawValue).joined(separator: ", ")));"
     }
 
+    /// Create an enumeration definition from it's stored properties.
+    /// 
+    /// This initialiser will check that the `nonEmptyValues` contains at least 1 value. If this is not the
+    /// case, then the initialiser will return `nil`.
+    /// - Parameters:
+    ///   - name: The name of the enumeration.
+    ///   - nonEmptyValues: The valid values within the enumeration.
+    /// - Warning: The `nonEmptyValues` array must contain at least 1 value.
+    @inlinable
     public init?(name: VariableName, nonEmptyValues: [VariableName]) {
         guard !nonEmptyValues.isEmpty else {
             return nil
@@ -73,6 +93,9 @@ public struct EnumerationDefinition: RawRepresentable, Equatable, Hashable, Coda
         self.init(name: name, values: nonEmptyValues)
     }
 
+    /// Create an enumeration definition from it's `VHDL` code defining it.
+    /// - Parameter rawValue: The `VHDL` code that defines a new type as an enumeration of values.
+    @inlinable
     public init?(rawValue: String) {
         let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
@@ -111,6 +134,11 @@ public struct EnumerationDefinition: RawRepresentable, Equatable, Hashable, Coda
         self.init(name: name, values: values)
     }
 
+    /// Set the stored properties of the enumeration without checking for validity.
+    /// - Parameters:
+    ///   - name: The name of this enumeration.
+    ///   - values: The valid values of this enumeration.
+    @inlinable
     init(name: VariableName, values: [VariableName]) {
         self.name = name
         self.values = values

--- a/Sources/VHDLParsing/EnumerationDefinition.swift
+++ b/Sources/VHDLParsing/EnumerationDefinition.swift
@@ -1,0 +1,119 @@
+// EnumerationDefinition.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2024 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+
+import Foundation
+import StringHelpers
+
+public struct EnumerationDefinition: RawRepresentable, Equatable, Hashable, Codable, Sendable {
+
+    public let name: VariableName
+
+    public let values: [VariableName]
+
+    public var rawValue: String {
+        "type \(name.rawValue) is (\(values.map(\.rawValue).joined(separator: ", ")));"
+    }
+
+    public init?(name: VariableName, nonEmptyValues: [VariableName]) {
+        guard !nonEmptyValues.isEmpty else {
+            return nil
+        }
+        self.init(name: name, values: nonEmptyValues)
+    }
+
+    public init?(rawValue: String) {
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            trimmedValue.count <= 4096,
+            trimmedValue.words.first?.lowercased() == "type",
+            trimmedValue.hasSuffix(";")
+        else {
+            return nil
+        }
+        let withoutType = trimmedValue
+            .dropLast(1).dropFirst(4).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            let rawName = withoutType.words.first,
+            withoutType.hasSuffix(")"),
+            let name = VariableName(rawValue: rawName)
+        else {
+            return nil
+        }
+        let withoutName = withoutType
+            .dropLast().dropFirst(rawName.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let rawIs = withoutName.words.first?.lowercased(), rawIs == "is" else {
+            return nil
+        }
+        let withoutIs = withoutName.dropFirst(2).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard withoutIs.hasPrefix("(") else {
+            return nil
+        }
+        let withoutBrackets = withoutIs.dropFirst().trimmingCharacters(in: .whitespacesAndNewlines)
+        let valuesRaw = withoutBrackets.components(separatedBy: ",")
+        let values = valuesRaw.compactMap {
+            VariableName(rawValue: $0.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        guard values.count == valuesRaw.count else {
+            return nil
+        }
+        self.init(name: name, values: values)
+    }
+
+    init(name: VariableName, values: [VariableName]) {
+        self.name = name
+        self.values = values
+    }
+
+}

--- a/Sources/VHDLParsing/TypeDefinition.swift
+++ b/Sources/VHDLParsing/TypeDefinition.swift
@@ -69,6 +69,9 @@ public enum TypeDefinition: RawRepresentable, Equatable, Hashable, Codable, Send
     /// An array type definition.
     case array(value: ArrayDefinition)
 
+    /// An enumeration type definition.
+    case enumeration(value: EnumerationDefinition)
+
     /// The equivalent `VHDL` code.
     @inlinable public var rawValue: String {
         switch self {
@@ -78,6 +81,8 @@ public enum TypeDefinition: RawRepresentable, Equatable, Hashable, Codable, Send
             return "type \(name.rawValue) is \(type.rawValue);"
         case .array(let array):
             return array.rawValue
+        case .enumeration(let enumeration):
+            return enumeration.rawValue
         }
     }
 
@@ -92,6 +97,10 @@ public enum TypeDefinition: RawRepresentable, Equatable, Hashable, Codable, Send
         }
         if let array = ArrayDefinition(rawValue: trimmedString) {
             self = .array(value: array)
+            return
+        }
+        if let enumeration = EnumerationDefinition(rawValue: trimmedString) {
+            self = .enumeration(value: enumeration)
             return
         }
         guard trimmedString.hasSuffix(";") else {

--- a/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
+++ b/Sources/VHDLParsing/VHDLParsing.docc/VHDLParsing.md
@@ -12,6 +12,7 @@
 - ``ComponentDefinition``
 - ``ConstantSignal``
 - ``Definition``
+- ``EnumerationDefinition``
 - ``ExternalType``
 - ``FunctionDefinition``
 - ``FunctionImplementation``

--- a/Tests/VHDLParsingTests/EnumerationDefinitionTests.swift
+++ b/Tests/VHDLParsingTests/EnumerationDefinitionTests.swift
@@ -74,7 +74,7 @@ final class EnumerationDefinitionTests: XCTestCase {
         )
     }
 
-    /// Test the `rawValue` created the correct `VHDL` code.
+    /// Test the `rawValue` creates the correct `VHDL` code.
     func testRawValue() {
         XCTAssertEqual(enumeration.rawValue, "type xs is (x0, x1, x2);")
     }
@@ -84,6 +84,52 @@ final class EnumerationDefinitionTests: XCTestCase {
         XCTAssertNil(EnumerationDefinition(name: VariableName(text: "xs"), nonEmptyValues: []))
         let enumeration2 = EnumerationDefinition(name: enumeration.name, nonEmptyValues: enumeration.values)
         XCTAssertEqual(enumeration2, enumeration)
+        let enumeration3 = EnumerationDefinition(
+            name: enumeration.name, nonEmptyValues: [VariableName(text: "x0")]
+        )
+        XCTAssertEqual(
+            enumeration3, EnumerationDefinition(name: enumeration.name, values: [VariableName(text: "x0")])
+        )
+    }
+
+    /// Tests that `init(rawValue:)` parses `VHDL` code correctly.
+    func testRawValueInit() {
+        let raw0 = "type xs is (x0, x1, x2);"
+        XCTAssertEqual(EnumerationDefinition(rawValue: raw0), enumeration)
+        let rawNewlines = """
+        type
+         xs
+          is
+           (
+             x0
+             ,
+                x1,
+                    x2
+           )
+        ;
+        """
+        XCTAssertEqual(EnumerationDefinition(rawValue: rawNewlines), enumeration)
+        XCTAssertNil(EnumerationDefinition(rawValue: String(raw0.dropLast())))
+        XCTAssertNil(EnumerationDefinition(rawValue: String(raw0.dropFirst(4))))
+        XCTAssertNil(EnumerationDefinition(rawValue: "type \(String(repeating: "x", count: 4096)) is (x0);"))
+        let raw1 = "type x!s is (x0, x1, x2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw1))
+        let raw2 = "type xs is (x0, x1, x2;"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw2))
+        let raw3 = "type xs (x0, x1, x2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw3))
+        let raw4 = "type xs iss (x0, x1, x2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw4))
+        let raw5 = "type xs is x0, x1, x2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw5))
+        let raw6 = "type xs is (x0, x1, x!2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw6))
+        let raw7 = "type xs is (x0, x!1, x2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw7))
+        let raw8 = "type xs is (x!0, x1, x2);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw8))
+        let raw9 = "type xs is (x!0);"
+        XCTAssertNil(EnumerationDefinition(rawValue: raw9))
     }
 
 }

--- a/Tests/VHDLParsingTests/EnumerationDefinitionTests.swift
+++ b/Tests/VHDLParsingTests/EnumerationDefinitionTests.swift
@@ -1,0 +1,89 @@
+// EnumerationDefinitionTests.swift
+// VHDLParsing
+// 
+// Created by Morgan McColl.
+// Copyright © 2024 Morgan McColl. All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials
+//    provided with the distribution.
+// 
+// 3. All advertising materials mentioning features or use of this
+//    software must display the following acknowledgement:
+// 
+//    This product includes software developed by Morgan McColl.
+// 
+// 4. Neither the name of the author nor the names of contributors
+//    may be used to endorse or promote products derived from this
+//    software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+// OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// 
+// -----------------------------------------------------------------------
+// This program is free software; you can redistribute it and/or
+// modify it under the above terms or under the terms of the GNU
+// General Public License as published by the Free Software Foundation;
+// either version 2 of the License, or (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see http://www.gnu.org/licenses/
+// or write to the Free Software Foundation, Inc., 51 Franklin Street,
+// Fifth Floor, Boston, MA  02110-1301, USA.
+
+@testable import VHDLParsing
+import XCTest
+
+/// Test class for ``EnumerationDefinition``.
+final class EnumerationDefinitionTests: XCTestCase {
+
+    /// Some test data.
+    let enumeration = EnumerationDefinition(
+        name: VariableName(text: "xs"),
+        values: [VariableName(text: "x0"), VariableName(text: "x1"), VariableName(text: "x2")]
+    )
+
+    /// Test property init.
+    func testInit() {
+        XCTAssertEqual(enumeration.name, VariableName(text: "xs"))
+        XCTAssertEqual(
+            enumeration.values,
+            [VariableName(text: "x0"), VariableName(text: "x1"), VariableName(text: "x2")]
+        )
+    }
+
+    /// Test the `rawValue` created the correct `VHDL` code.
+    func testRawValue() {
+        XCTAssertEqual(enumeration.rawValue, "type xs is (x0, x1, x2);")
+    }
+
+    /// Test public property init.
+    func testPropertyInit() {
+        XCTAssertNil(EnumerationDefinition(name: VariableName(text: "xs"), nonEmptyValues: []))
+        let enumeration2 = EnumerationDefinition(name: enumeration.name, nonEmptyValues: enumeration.values)
+        XCTAssertEqual(enumeration2, enumeration)
+    }
+
+}

--- a/Tests/VHDLParsingTests/TypeDefinitionTests.swift
+++ b/Tests/VHDLParsingTests/TypeDefinitionTests.swift
@@ -69,6 +69,12 @@ final class TypeDefinitionTests: XCTestCase {
         ]
     )
 
+    /// An enumeration definition.
+    let enumeration = EnumerationDefinition(
+        name: VariableName(text: "xs"),
+        values: [VariableName(text: "x0"), VariableName(text: "x1"), VariableName(text: "x2")]
+    )
+
     /// Test `rawValue` generates `VHDL` code correctly.
     func testRawValue() {
         XCTAssertEqual(TypeDefinition.record(value: record).rawValue, record.rawValue)
@@ -88,6 +94,7 @@ final class TypeDefinitionTests: XCTestCase {
             )).rawValue,
             "type xs is array (3 downto 0) of std_logic;"
         )
+        XCTAssertEqual(TypeDefinition.enumeration(value: enumeration).rawValue, enumeration.rawValue)
     }
 
     /// Test `init(rawValue:)` parses the `VHDL` code correctly.
@@ -109,6 +116,7 @@ final class TypeDefinitionTests: XCTestCase {
                 elementType: .signal(type: .stdLogic)
             ))
         )
+        XCTAssertEqual(TypeDefinition(rawValue: "type xs is (x0, x1, x2);"), .enumeration(value: enumeration))
         XCTAssertNil(TypeDefinition(rawValue: "type x is std_logic"))
         XCTAssertNil(TypeDefinition(rawValue: ""))
         XCTAssertNil(TypeDefinition(rawValue: "type 2x is std_logic;"))


### PR DESCRIPTION
This PR adds support for parsing enumerable type definitions. For example, the `VHDL` code below defines a new type `xs` as a set of possible values.

```vhdl
type xs is (x0, x1, x2);
```

This type is now represented using the `EnumerationDefinition` type within this package and may also be used as a new case in `TypeDefinition`.