### PR TITLE
Add new member case in Type.

### DIFF
--- a/Sources/VHDLParsing/Type.swift
+++ b/Sources/VHDLParsing/Type.swift
@@ -95,9 +95,11 @@ public enum Type: RawRepresentable, Equatable, Hashable, Codable, Sendable {
             return
         }
         let components = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: ".")
-        guard components.allSatisfy({
-            $0.trimmingCharacters(in: .whitespacesAndNewlines).count == $0.count
-        }) else {
+        guard
+            components.allSatisfy({
+                $0.trimmingCharacters(in: .whitespacesAndNewlines).count == $0.count
+            })
+        else {
             return nil
         }
         let names = components.compactMap(VariableName.init(rawValue:))

--- a/Sources/VHDLParsing/Type.swift
+++ b/Sources/VHDLParsing/Type.swift
@@ -64,6 +64,7 @@ public enum Type: RawRepresentable, Equatable, Hashable, Codable, Sendable {
     /// A user-defined type with name `name`.
     case alias(name: VariableName)
 
+    /// A namespaced type existing within an external resource.
     case member(components: [VariableName])
 
     /// A pre-defined type that exists within VHDL.

--- a/Tests/VHDLParsingTests/TypeTests.swift
+++ b/Tests/VHDLParsingTests/TypeTests.swift
@@ -66,18 +66,29 @@ final class TypeTests: XCTestCase {
     /// A variable `x`.
     let x = VariableName(text: "x")
 
+    /// A variable `y`.
+    let y = VariableName(text: "y")
+
+    /// A variable `z`.
+    let z = VariableName(text: "z")
+
     /// Test the `rawValue` generates the correct `VHDL` code.
     func testRawValue() {
         XCTAssertEqual(Type.alias(name: x).rawValue, "x")
         XCTAssertEqual(Type.signal(type: signal).rawValue, "std_logic")
+        XCTAssertEqual(Type.member(components: [x, y, z]).rawValue, "x.y.z")
     }
 
     /// Test `init(rawValue:)` returns the correct `Type`.
     func testRawValueInit() {
         XCTAssertEqual(Type(rawValue: "x"), .alias(name: x))
         XCTAssertEqual(Type(rawValue: "std_logic"), .signal(type: signal))
+        XCTAssertEqual(Type(rawValue: "x.y.z"), .member(components: [x, y, z]))
         XCTAssertNil(Type(rawValue: ""))
         XCTAssertNil(Type(rawValue: "2x"))
+        XCTAssertNil(Type(rawValue: "x.y.z."))
+        XCTAssertNil(Type(rawValue: "x . y. z"))
+        XCTAssertNil(Type(rawValue: "x.y z"))
     }
 
 }


### PR DESCRIPTION
This PR adds support for defining references to namespaced types that exist within imported modules.

E.g., you may now parse types that match the given syntax:

```vhdl
signal x: IEEE.std_logic_1164.std_logic;
```